### PR TITLE
Bani certidoc

### DIFF
--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -183,6 +183,29 @@ Customers using the Customer Portal can rest their SIP Passwords in [**Authentic
 
 Use `Send` next to the SIP User to send a SIP message to the end device which will flash on the phone.
 
+### SIP Pings
+
+**Case 1: Normal SIP Ping**
+
+```mermaid
+    sequenceDiagram
+    autonumber
+    Alice->>Bob: INVITE (cseq 1)
+    Bob-->>Alice: 100 Trying
+    Bob-->>Alice: 183 Ringing
+    Bob->>Alice: 200 OK (Connected)
+    Alice->>Bob: ACK
+    Note over Alice,Bob: The call is active
+    Bob->>Alice: OPTIONS
+    Alice->>Bob: 200 OK
+    Note over Alice,Bob: The call has ended
+    Alice->>Bob: BYE
+    Bob->>Alice: 200 OK
+```
+In this case, Bob sends a message to Alice called **OPTIONS** and Alice sends back **200 OK**. If **200 OK** is not sent, the call be get disconnected.
+
+**Case 2: Alice Disappears**
+
 ### Use Case for NAT/SIP Pings
 
 **Troubleshooting Scenario**

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -282,6 +282,23 @@ In this case, when we send the OPTION packet to Charlie, he doesn't reply. The O
 
 Another scenario is when ConnexCS sends message to Charlie and Charlie is active on the call, he will send a BYE message to Alice and we won't see a reply to that.
 
++ **ACK Message**
+
+An ACK is an **Acknowledgement** of a final reply.
+
+```mermaid
+    sequenceDiagram
+    autonumber
+    Alice->>Bob: INVITE
+    Bob-->>Alice: 100 Trying
+    Bob-->>Alice: 180 Ringing
+    Bob->>Alice: 200 OK (Connected)
+    Alice->>Bob: ACK
+    Note over Alice,Bob: The call is active
+    Alice->>Bob: BYE
+    Bob->>Alice: 200 OK
+```
+
 ### Use Case for NAT/SIP Pings
 
 **Troubleshooting Scenario**

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -98,6 +98,28 @@ Generic SIP Trace showing the Challenge Response:
 
 &emsp; ![alt text][407-trace]
 
+```mermaid
+    sequenceDiagram
+    autonumber
+    Alice->>Bob: INVITE
+    Bob-->>Alice: 100 Trying
+    Bob->>Alice: 407 Proxy Authentication Required
+    Note over Alice,Bob: 407 contains nonce.
+    Note left of Alice: HASH(Combine Password + Nonce).
+    Alice->>Bob: INVITE (+ Auth Header)
+    Bob-->>Alice: 100 Trying
+    Note right of Bob: HASH(Combine Password + Nonce).
+    Note right of Bob: Compare Hashes - They Match.
+    Bob-->>Alice: 183 Ringing
+    Bob->>Alice: 200 OK (Connected)
+```
+
+For call authentication we should have a Username and a Password. The Username and Password should get to the other side.
+
+The Username is sent on Plain-text and the user (Alice) hashes the password. **407** contains a nonce. A nonce is a random String of which gets send over to Alice. Both Alice and Bob are aware of this random string. Authorization header is sent with the INVITE. Then Bob combines the password with the nonce and compares the nonce. If the hashes match, the call gets connected.
+
+!!! note "407 Proxy Authentication is a part of Challenge-Response and is necessary when you proceed with SIP User Auth. Also you cannot have IP Authentication and SIP Authentication work together"
+
 ### Enable SIP User Authentication
 
 To enable, click **:material-plus:** next to SIP User Authentication:

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -116,7 +116,7 @@ Generic SIP Trace showing the Challenge Response:
 
 For call authentication we should have a Username and a Password. The Username and Password should get to the other side.
 
-The Username is sent on Plain-text and the user (Alice) hashes the password. **407** contains a nonce. A nonce is a random String of which gets send over to Alice. Both Alice and Bob are aware of this random string. Authorization header is sent with the INVITE. Then Bob combines the password with the nonce and compares the nonce. If the hashes match, the call gets connected.
+The Username is sent on Plain-text and the user (Alice) hashes the password. [**407 Proxy Authentication**](https://en.wikipedia.org/wiki/List_of_SIP_response_codes#4xx%E2%80%94Client_Failure_Responses) contains a nonce. A nonce is a random String of which gets send over to Alice. Both Alice and Bob are aware of this random string. Authorization header is sent with the INVITE. Then Bob combines the password with the nonce and compares the nonce. If the hashes match, the call gets connected.
 
 !!! note "407 Proxy Authentication is a part of Challenge-Response and is necessary when you proceed with SIP User Auth. Also you cannot have IP Authentication and SIP Authentication work together"
 
@@ -342,6 +342,12 @@ Bob should send 487 Canceled message to Alice.
     Alice->>Bob: CANCEL (Alternative, Ringing Too Long)
     Bob->>Alice: 487 Canceled
 ```
+
++ **200 OK Message**
+
+**200 OK** is a Success message. In order to understand how the **200 OK** is related to we need to follow back the original cseq.
+
+For example, if you don't see a 200 OK for a BYE message it means the other side has disappeared.
 
 ### Use Case for NAT/SIP Pings
 

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -299,6 +299,28 @@ An ACK is an **Acknowledgement** of a final reply.
     Bob->>Alice: 200 OK
 ```
 
++ **Cancel Message**
+
+**CANCEL** message indicates that the previous request was terminated by user. In this case, the CANCEL message is sent from Alice to Bob.
+
+Cancel can be due to PDD timer is too high or ringing exists for a longer duration.
+
+Bob should send 487 Canceled message to Alice.
+
+```mermaid
+    sequenceDiagram
+    autonumber
+    Alice->>Bob: INVITE
+    Bob-->>Alice: 100 Trying
+    Alice->>Bob: CANCEL (PDD Too High)
+    Bob->>Alice: 487 Canceled
+    Alice->>Bob: INVITE
+    Bob-->>Alice: 100 Trying
+    Bob-->>Alice: 180 Ringing
+    Alice->>Bob: CANCEL (Alternative, Ringing Too Long)
+    Bob->>Alice: 487 Canceled
+```
+
 ### Use Case for NAT/SIP Pings
 
 **Troubleshooting Scenario**

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -118,7 +118,7 @@ For call authentication we should have a Username and a Password. The Username a
 
 The Username is sent on Plain-text and the user (Alice) hashes the password. [**407 Proxy Authentication**](https://en.wikipedia.org/wiki/List_of_SIP_response_codes#4xx%E2%80%94Client_Failure_Responses) contains a nonce. A nonce is a random String of which gets send over to Alice. Both Alice and Bob are aware of this random string. Authorization header is sent with the INVITE. Then Bob combines the password with the nonce and compares the nonce. If the hashes match, the call gets connected.
 
-!!! note "407 Proxy Authentication is a part of Challenge-Response and is necessary when you proceed with SIP User Auth. Also you cannot have IP Authentication and SIP Authentication work together"
+!!! note "407 Proxy Authentication is a part of Challenge-Response and is necessary when you proceed with SIP User Auth. Also you can't have **IP Authentication** and **User / Password Authentication** work together"
 
 ### Enable SIP User Authentication
 

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -301,9 +301,9 @@ An ACK is an **Acknowledgement** of a final reply.
 
 + **Cancel Message**
 
-**CANCEL** message indicates that the previous request was terminated by user. In this case, the CANCEL message is sent from Alice to Bob.
+**CANCEL** message indicates that the previous request was terminated by the user. In this case, the CANCEL message is sent from Alice to Bob.
 
-Cancel can be due to PDD timer is too high or ringing exists for a longer duration.
+Cancel can be due to PDD timer being too high or ringing exists for a longer duration.
 
 Bob should send 487 Canceled message to Alice.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -269,14 +269,17 @@ Here, Alice starts a call with Bob, the call is active without any issues and th
 
 The causes of a dropped call are:
 
- 1. **Downstream BYE**: When the call disconnects from the **originator's** side via a **BYE** message.
- 2. **Upstream BYE**: When the call disconnects from the **receiver** side via a **BYE** message.
- 3. **MI Termination**: The system terminates the call when it finds that there has been no audio connection between the call's originator and the receiver.
+ 1. **Downstream BYE:** When the call disconnects from the **originator's** side via a **BYE** message.
+ 2. **Upstream BYE:** When the call disconnects from the **receiver** side via a **BYE** message.
+ 3. **MI Termination:** The system terminates the call when it finds that there has been no audio connection between the call's originator and the receiver.
 
      The system triggers a BYE message on both sides within the application.
 
- 4. **Ping Timeout**: If you enable the Sip Ping feature under Customer:material-menu-right: Routing, the receiver and originator receives OPTION packets (every X seconds).
+ 4. **Ping Timeout:** If you enable the Sip Ping feature under Customer:material-menu-right: Routing, the receiver and originator receives OPTION packets (every X seconds).
 
     The originator and the receiver should reply with 200 OK after receiving the OPTION packets. If either the originator or receiver misses sending the acknowledgment, the call terminates due to a "ping timeout."
 
     It prevents any long-duration calls as the system recognizes either the originator or receiver as inactive.
+5. **Missing ACK:** We can if a call gets disconnected within 5 seconds, its because an Acknowledgement wasn't received
+6. **Missing SIP Ping:** We can if a call gets disconnected within 20-30 seconds, its because of a missing SIP Ping.
+7. **Missing Re-Invite:** We can if a call gets disconnected within 5 minutes, its because of a missing Re-Invite message.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -87,11 +87,11 @@ Here is an example describing a SIP trace:
     Bob->>Alice: 200 OK
 ```
 
-Alice and Bob represents party on the call. Alice sends an **INVTE** packet to Bob. Then Bob sends a **100 Trying** (provides you the feedback that your request is getting processed by a SIP Application) message together with **180 Ringing** (the Destination User Agent has received the INVITE message and is alerting the user of call).
+Alice and Bob represent the parties on the call. Alice sends an **INVITE** packet to Bob. Then Bob sends a **100 Trying** (provides you the feedback that your request is getting processed by a SIP Application) message together with **180 Ringing** (the Destination User Agent has received the INVITE message and is alerting the user of the call).
 
 Further, **200 OK** is sent which means the calls are connected.
 
-The **ACK** is message is sent from Alice to Bob confirming that the call has been connected.
+The **ACK** message is sent from Alice to Bob confirming that the call has been connected.
 
 ![sip trace](/logging/sipserver.jpg)
 
@@ -159,11 +159,11 @@ end
 end
 ```
 
-Alice and Bob represents party on the call. Alice sends an INVTE packet to Bob. INVITE is an initial request.
+Alice and Bob represent the parties on the call. Alice sends an INVITE packet to Bob. INVITE is an initial request.
 
-Then Bob sends a 100 Trying (provides you the feedback that your request is getting processed by a SIP Application) message along-with 180 Ringing (the Destination User Agent has received the INVITE message and is alerting the user of call). 100 Trying and 180 Ringing are provisional response.
+Then Bob sends a 100 Trying (provides you the feedback that your request is getting processed by a SIP Application) message along with 180 Ringing (the Destination User Agent has received the INVITE message and is alerting the user of the call). 100 Trying and 180 Ringing are provisional responses.
 
-The re-invtes get absorbed when they're received. When Bob receives the INVITE packet and a special timer is set (please see the below timer table) as to how long it should wait for re-transmissions. If any packet is received within this time-frame, the packet gets ignored.
+The re-invites get absorbed when they're received. When Bob receives the INVITE packet and a special timer is set (please see the below timer table) as to how long it should wait for re-transmissions. If any packet is received within this time frame, the packet gets ignored.
 
 Further, 200 OK is sent which means the calls are connected. 200 OK is a final reply.
 
@@ -171,11 +171,11 @@ The ACK is message is sent from Alice to Bob confirming that the call has been c
 
 Each line is a Message.
 
-From 1 message (INVITE) till message 5 (ACK), it's considered as a single Transaction.
+From 1 message (INVITE) to message 5 (ACK), it's considered as a single Transaction.
 
-Similarly message 6 (BYE) and 7 (200 OK) are also considered as a single Transaction.
+Similarly, messages 6 (BYE) and 7 (200 OK) are also considered as a single Transaction.
 
-From message 1 till message 7, the whole conversation is a Dialog.
+From message 1 to message 7, the whole conversation is a Dialog.
 
 !!! note "Note"
     Message displayed in Pink color.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -116,7 +116,7 @@ To view the SIP Trace of a call:
     * **Missed call attempts**: If using SIP authentication, because there are two requests, it's possible that they hit our database out of order. This may cause the logging page to only display the first call attempt.
     * Considered for reporting calls and don't impact the calls directly. They're both rare, typically observed in less than 1 in every 50,000 calls.
 
-### **Re-Transmissions:** 
+### **Re-Transmissions** 
 Re-transmissions occur when the same INVITE is sent more than once. This means the `same` packets were sent more than once.
 
 Re-transmissions only happen on UDP. Re-transmissions occur when packets either don't reach the receiver or get lost in transmission. Thus, re-transmissions are done after a certain time interval using specific timers.
@@ -226,11 +226,11 @@ You can have take a look at the various SIP Timers in the table below:
 
 Here, Alice sends an invite to Bob and it's expected to get a reply (100 Trying) within in 500ms which is a **First Reply Timer**.
 
-Then a **PDD timer** is set for 5s to hear the ringing. Post-dial delay (PDD) is the measurement of how long it takes for a calling party to hear a ring back tone after initiating a call.
+Then a **PDD timer** is set for 5s to hear the ringing. Post-dial delay (PDD) is the measurement of how long it takes for a calling party to hear a ring-back tone after initiating a call.
 
 The time from when the respondent's phone starts ringing until it's answered; is a **Ring Timer**.
 
-When the call is active **Max Call Duration Timer** comes into picture. When this timer is active, the active call gets disconnected when it reaches the maximum time of an active call.
+When the call is active **Max Call Duration Timer** comes into the picture. When this timer is active, the active call gets disconnected when it reaches the maximum time of an active call.
 
 [logging-sip]: /misc/img/logging-sip.png "SIP Traces"
 [logging-4]: /misc/img/236.png "logging-4"

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -177,7 +177,10 @@ Similarly message 6 (BYE) and 7 (200 OK) are also considered as a single Transac
 
 From message 1 till message 7, the whole conversation is a Dialog.
 
-!!! note "Note" Message displayed in Pink color. Transaction displayed in Blue color. Dialog displayed in Violet color.
+!!! note "Note" 
+    Message displayed in Pink color.
+    Transaction displayed in Blue color. 
+    Dialog displayed in Violet color.
 
 You can have take a look at the various SIP Timers in the table below:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -315,8 +315,8 @@ The causes of a dropped call are:
      The originator and the receiver should reply with 200 OK after receiving the OPTION packets. If either the originator or receiver misses sending the acknowledgment, the call terminates due to a "ping timeout."
      It prevents any long-duration calls as the system recognizes either the originator or receiver as inactive.
 
-5. **Missing ACK:** We can if a call gets disconnected within 5 seconds, its because an Acknowledgement wasn't received
+5. **Missing ACK:** If a call gets disconnected within 5 seconds, its because an Acknowledgement wasn't received
 
-6. **Missing SIP Ping:** We can if a call gets disconnected within 20-30 seconds, its because of a missing SIP Ping.
+6. **Missing SIP Ping:** If a call gets disconnected within 20-30 seconds, its because of a missing SIP Ping.
 
-7. **Missing Re-Invite:** We can if a call gets disconnected within 5 minutes, its because of a missing Re-Invite message.
+7. **Missing Re-Invite:** If a call gets disconnected within 5 minutes, its because of a missing Re-Invite message.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -177,9 +177,9 @@ Similarly message 6 (BYE) and 7 (200 OK) are also considered as a single Transac
 
 From message 1 till message 7, the whole conversation is a Dialog.
 
-!!! note "Note" 
+!!! note "Note"
     Message displayed in Pink color.
-    Transaction displayed in Blue color. 
+    Transaction displayed in Blue color.
     Dialog displayed in Violet color.
 
 You can have take a look at the various SIP Timers in the table below:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -206,15 +206,41 @@ You can have take a look at the various SIP Timers in the table below:
 
 <font size="2">*Table source*: [**IBM**](https://www.ibm.com/docs/en/was/8.5.5?topic=timers-sip-timer-summary); *Original Ref*: [**RFC 3261**](https://www.ietf.org/rfc/rfc3261.txt)</font size>
 
++ **Various Timers**
+
+```mermaid
+     sequenceDiagram
+    autonumber
+    Alice->>Bob: INVITE
+    Note over Alice,Bob: First Reply Timer (500ms)
+    Bob-->>Alice: 100 Trying
+    Note over Alice,Bob: PDD Timer (5s)
+    Bob-->>Alice: 180 Ringing
+    Note over Alice,Bob: Ring Timer (30s)
+    Bob->>Alice: 200 OK (Connected)
+    Alice->>Bob: ACK
+    Note over Alice,Bob: Max Call Duration Timer (1 hour)
+    Alice->>Bob: BYE
+    Bob->>Alice: 200 OK
+```
+
+Here, Alice sends an invite to Bob and it's expected to get a reply (100 Trying) within in 500ms which is a **First Reply Timer**.
+
+Then a **PDD timer** is set for 5s to hear the ringing. Post-dial delay (PDD) is the measurement of how long it takes for a calling party to hear a ring back tone after initiating a call.
+
+The time from when the respondent's phone starts ringing until it's answered; is a **Ring Timer**.
+
+When the call is active **Max Call Duration Timer** comes into picture. When this timer is active, the active call gets disconnected when it reaches the maximum time of an active call.
+
 [logging-sip]: /misc/img/logging-sip.png "SIP Traces"
 [logging-4]: /misc/img/236.png "logging-4"
 
 ### Re-Invite
 
 ```mermaid
-    sequenceDiagram
-    autonumber
-    Alice->>Bob: INVITE (cseq 1)
+   sequenceDiagram
+   autonumber
+   Alice->>Bob: INVITE (cseq 1)
     Bob-->>Alice: 100 Trying
     Bob->>Charlie: INVITE (cseq 1)
     Charlie-->>Bob: 100 Trying
@@ -235,7 +261,6 @@ You can have take a look at the various SIP Timers in the table below:
     Alice->>Bob: 200 OK
     Bob->>Charlie: 200 OK
 ```
-
 In case of a Re-Invite, it re-establishes an entire call.
 
 Here, Alice starts a call with Bob, the call is active without any issues and the media is through UK. But as a provider we detect the call isn't going through UK. Thus, we send the Re-Invite to Alice to send the media through us and we can place the call on a different server in real-time and in the middle of the call. Thus, a Re-Invite can contain some extra information also.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -269,8 +269,30 @@ Here, Alice starts a call with Bob, the call is active without any issues and th
 
 The causes of a dropped call are:
 
- 1. **Downstream BYE:** When the call disconnects from the **originator's** side via a **BYE** message.
+ 1. **Downstream BYE:** When the call disconnects from the **originator's** side via a **BYE** message. 
+
+```mermaid
+    sequenceDiagram
+    autonumber
+    Downstream->>ConnexCS: BYE
+    ConnexCS->>Upstream: BYE
+    Upstream->>ConnexCS: 200 OK
+    ConnexCS->>Downstream: 200 OK
+```
+
  2. **Upstream BYE:** When the call disconnects from the **receiver** side via a **BYE** message.
+
+```mermaid    
+    sequenceDiagram
+    autonumber
+    participant Downstream
+    participant ConnexCS
+    Upstream->>ConnexCS: BYE
+    ConnexCS->>Downstream: BYE
+    Downstream->>ConnexCS: 200 OK
+    ConnexCS->>Upstream: 200 OK
+```
+
  3. **MI Termination:** The system terminates the call when it finds that there has been no audio connection between the call's originator and the receiver.
 
      The system triggers a BYE message on both sides within the application.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -72,6 +72,27 @@ Uses of SIP protocol include call setup, maintenance, and tear-down, this tool i
 
 Call quality issues are often identified using other methods.
 
+Here is an example describing a SIP trace:
+
+```mermaid
+    sequenceDiagram
+    autonumber
+    Alice->>Bob: INVITE
+    Bob-->>Alice: 100 Trying
+    Bob-->>Alice: 180 Ringing
+    Bob->>Alice: 200 OK (Connected)
+    Alice->>Bob: ACK
+    Note over Alice,Bob: The call is active
+    Alice->>Bob: BYE
+    Bob->>Alice: 200 OK
+```
+
+Alice and Bob represents party on the call. Alice sends an **INVTE** packet to Bob. Then Bob sends a **100 Trying** (provides you the feedback that your request is getting processed by a SIP Application) message together with **180 Ringing** (the Destination User Agent has received the INVITE message and is alerting the user of call).
+
+Further, **200 OK** is sent which means the calls are connected.
+
+The **ACK** is message is sent from Alice to Bob confirming that the call has been connected.
+
 ![sip trace](/logging/sipserver.jpg)
 
 !!! info "SIP Trace Captures"
@@ -98,6 +119,65 @@ To view the SIP Trace of a call:
 * **Re-Transmissions:** Re-transmissions occur when the same INVITE is sent more than once. This means the `same` packets were sent more than once.
 
     Re-transmissions only happen on UDP. Re-transmissions occur when packets either don't reach the receiver or get lost in transmission. Thus, re-transmissions are done after a certain time interval using specific timers.
+
+    Here is an example describing Re-transmissions:
+
+```mermaid
+sequenceDiagram
+autonumber
+rect rgb(127, 0, 255)
+rect rgb(100, 180, 255)
+rect rgb(252, 110,153)
+Alice->>Bob: INVITE (cseq 1)
+end
+Note over Alice,Bob: 500ms delay
+rect rgb(252, 110,153)
+Alice->>Bob: INVITE (cseq 1)
+end
+rect rgb(252, 110,153)
+Bob-->>Alice: 100 Trying
+end
+rect rgb(252, 110,153)
+Bob-->>Alice: 180  Ringing
+end
+rect rgb(252, 110,153)
+Bob->>Alice: 200 OK (Connected)
+end
+rect rgb(252, 110,153)
+Alice->>Bob: ACK
+end
+end
+Note over Alice,Bob: The call is active
+rect rgb(100, 180, 255)
+rect rgb(252, 110,153)
+Alice->>Bob: BYE
+end
+rect rgb(252, 110,153)
+Bob->>Alice: 200 OK
+end
+end
+end
+```
+
+Alice and Bob represents party on the call. Alice sends an INVTE packet to Bob. INVITE is an initial request.
+
+Then Bob sends a 100 Trying (provides you the feedback that your request is getting processed by a SIP Application) message along-with 180 Ringing (the Destination User Agent has received the INVITE message and is alerting the user of call). 100 Trying and 180 Ringing are provisional response.
+
+The re-invtes get absorbed when they're received. When Bob receives the INVITE packet and a special timer is set (please see the below timer table) as to how long it should wait for re-transmissions. If any packet is received within this time-frame, the packet gets ignored.
+
+Further, 200 OK is sent which means the calls are connected. 200 OK is a final reply.
+
+The ACK is message is sent from Alice to Bob confirming that the call has been connected.
+
+Each line is a Message.
+
+From 1 message (INVITE) till message 5 (ACK), it's considered as a single Transaction.
+
+Similarly message 6 (BYE) and 7 (200 OK) are also considered as a single Transaction.
+
+From message 1 till message 7, the whole conversation is a Dialog.
+
+!!! note "Note" Message displayed in Pink color. Transaction displayed in Blue color. Dialog displayed in Violet color.
 
 You can have take a look at the various SIP Timers in the table below:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -116,11 +116,12 @@ To view the SIP Trace of a call:
     * **Missed call attempts**: If using SIP authentication, because there are two requests, it's possible that they hit our database out of order. This may cause the logging page to only display the first call attempt.
     * Considered for reporting calls and don't impact the calls directly. They're both rare, typically observed in less than 1 in every 50,000 calls.
 
-* **Re-Transmissions:** Re-transmissions occur when the same INVITE is sent more than once. This means the `same` packets were sent more than once.
+### **Re-Transmissions:** 
+Re-transmissions occur when the same INVITE is sent more than once. This means the `same` packets were sent more than once.
 
-    Re-transmissions only happen on UDP. Re-transmissions occur when packets either don't reach the receiver or get lost in transmission. Thus, re-transmissions are done after a certain time interval using specific timers.
+Re-transmissions only happen on UDP. Re-transmissions occur when packets either don't reach the receiver or get lost in transmission. Thus, re-transmissions are done after a certain time interval using specific timers.
 
-    Here is an example describing Re-transmissions:
+Here is an example describing Re-transmissions:
 
 ```mermaid
 sequenceDiagram
@@ -207,6 +208,37 @@ You can have take a look at the various SIP Timers in the table below:
 
 [logging-sip]: /misc/img/logging-sip.png "SIP Traces"
 [logging-4]: /misc/img/236.png "logging-4"
+
+### Re-Invite
+
+```mermaid
+    sequenceDiagram
+    autonumber
+    Alice->>Bob: INVITE (cseq 1)
+    Bob-->>Alice: 100 Trying
+    Bob->>Charlie: INVITE (cseq 1)
+    Charlie-->>Bob: 100 Trying
+    Charlie-->>Bob: 180 Ringing
+    Bob-->>Alice: 180 Ringing
+    Charlie->>Bob: 200 OK (Connected)
+    Bob->>Alice: 200 OK (Connected)
+    Alice->>Bob: ACK
+    Bob->>Charlie: ACK
+    Note over Alice,Charlie: The call is active
+    Bob->>Alice: REINVITE
+    Alice->>Bob: 200 OK
+    Bob->>Charlie: REINVITE
+    Charlie->>Bob: 200 OK
+    Note over Alice,Charlie: Call Disconnects
+    Charlie->>Bob: BYE
+    Bob->>Alice: BYE
+    Alice->>Bob: 200 OK
+    Bob->>Charlie: 200 OK
+```
+
+In case of a Re-Invite, it re-establishes an entire call.
+
+Here, Alice starts a call with Bob, the call is active without any issues and the media is through UK. But as a provider we detect the call isn't going through UK. Thus, we send the Re-Invite to Alice to send the media through us and we can place the call on a different server in real-time and in the middle of the call. Thus, a Re-Invite can contain some extra information also.
 
 ## Call Release Reasons
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -276,10 +276,11 @@ The causes of a dropped call are:
      The system triggers a BYE message on both sides within the application.
 
  4. **Ping Timeout:** If you enable the Sip Ping feature under Customer:material-menu-right: Routing, the receiver and originator receives OPTION packets (every X seconds).
+     The originator and the receiver should reply with 200 OK after receiving the OPTION packets. If either the originator or receiver misses sending the acknowledgment, the call terminates due to a "ping timeout."
+     It prevents any long-duration calls as the system recognizes either the originator or receiver as inactive.
 
-    The originator and the receiver should reply with 200 OK after receiving the OPTION packets. If either the originator or receiver misses sending the acknowledgment, the call terminates due to a "ping timeout."
-
-    It prevents any long-duration calls as the system recognizes either the originator or receiver as inactive.
 5. **Missing ACK:** We can if a call gets disconnected within 5 seconds, its because an Acknowledgement wasn't received
+
 6. **Missing SIP Ping:** We can if a call gets disconnected within 20-30 seconds, its because of a missing SIP Ping.
+
 7. **Missing Re-Invite:** We can if a call gets disconnected within 5 minutes, its because of a missing Re-Invite message.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -116,7 +116,21 @@ To view the SIP Trace of a call:
     * **Missed call attempts**: If using SIP authentication, because there are two requests, it's possible that they hit our database out of order. This may cause the logging page to only display the first call attempt.
     * Considered for reporting calls and don't impact the calls directly. They're both rare, typically observed in less than 1 in every 50,000 calls.
 
-### **Re-Transmissions** 
++ **How to correlate a Reply to an Initial Request**
+
+The correlation of a Reply to an Initial Request can be done when the Invites have the same CSequence
+
+```mermaid
+    sequenceDiagram
+    autonumber
+    Alice->>Bob: INVITE (cseq 123)
+    Bob-->>Alice: 100 Trying
+    Bob-->>Alice: 180 Ringing
+    Bob->>Alice: 408 Ring Timeout (cseq 123 INVITE)
+```
+
+### **Re-Transmissions**
+
 Re-transmissions occur when the same INVITE is sent more than once. This means the `same` packets were sent more than once.
 
 Re-transmissions only happen on UDP. Re-transmissions occur when packets either don't reach the receiver or get lost in transmission. Thus, re-transmissions are done after a certain time interval using specific timers.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -74,7 +74,8 @@ If your Session Initiation Protocol (SIP) Trace shows that an INVITE packet was 
 
 | SIP Code | SIP Reason| Details|
 |:--------:|----------------------------------------|--------------------------------------------------------------------------------------------------------|
-|    **401**   | IP Not Authorised| The IP Address doesn't match any account in the system.|
+|**401**| IP Not Authorised| The IP Address doesn't match any account in the system.|
+|**404**|Not Found | The number does not exist.|
 |**408**| Request Timeout|If the request wasn't answered or wasn't able to get a reply from the other side|
 |**487**| Request Terminated|If the caller closes the phone before connection|
 |**500**| Unidentified Internal Switch| This is an internal error; you should never see this. If you do please contact us.|
@@ -93,6 +94,10 @@ If your Session Initiation Protocol (SIP) Trace shows that an INVITE packet was 
 |**580**| Switch IP Variable Not Provided| This is an internal error; you should never see this. If you do please contact us.|
 |**580**| To (oU) User Missing| This is an internal error; you should never see this. If you do please contact us.|
 |**580**| To (fU) User Missing| This is an internal error; you should never see this. If you do please contact us.|
+
+!!! note "4XX vs 5XX"
+    4xx codes are Client Failure Responses, while 5XX are Server Failure Responses. 
+    For example, it doesn't mean that the server couldn't deliver the call but it means the server knows that the number doesn't exist.
 
 !!! info "End Point synchronisation"
     When making changes, although we try to synchronise all endpoints instantly, as this is a distributed system, it can take up to 60 seconds for any changes to take effect.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -72,25 +72,27 @@ F --> G(Far-End)
 
 If your Session Initiation Protocol (SIP) Trace shows that an INVITE packet was received by the switch but not sent out to any providers, the failure has occurred in the **Ingress Routing**.
 
-| SIP Code | SIP Reason                             | Details                                                                                                |
+| SIP Code | SIP Reason| Details|
 |:--------:|----------------------------------------|--------------------------------------------------------------------------------------------------------|
-|    **401**   | IP Not Authorised                      | The IP Address doesn't match any account in the system.                                               |
-|    **500**   | Unidentified Internal Switch           | This is an internal error; you should never see this. If you do please contact us.                     |
-|    **500**   | Server not accepting calls (Paused)    | Either your account or server gets disabled with ConnexCS.                         |
-|    **503**   | Unknown User                           | Username & Passwords don't match to any known user account.                                           |
-|    **503**   | Unable to perform LRN                  | You have selected LRN (Location Routing Number) dipping for this route, so it's likely that you don't have credit with us. |
-|    **503**   | LCR Unavailable                        | The system is unable to perform a Least Cost Routing (LCR) lookup.                                                          |
-|    **503**   | Blocked by Dial plan                    | The prefix/number isn't matched by the allowed dial plan.                                             |
-|    **503**   | No Routes Available (Pre)              | No rate card rule to allow the call to progress.                                              |
-|    **503**   | No Routes Available (U)                | No routes are available either due to: Lock, Profit Assurance, Routing Strategy or ScriptForge.        |
-|    **503**   | No Routes Available (Lock)             | Locking your Ingress routing has left no routing options.                                              |
-|    **503**   | No Routes Available (Profit Assurance) | Profit Assurance has left no routing options.                                                          |
-|    **503**   | Dropping Call (Strategy)               | Strategic Routing has dropped the call.                                                                |
-|    **503**   | Internal Strategic Routing Error       | An error with the config of Strategic Routing.                                                |
-|    **580**   | No Route Available                     | The number dialled doesn't match any ingress routing profile.                                         |
-|    **580**   | Switch IP Variable Not Provided        | This is an internal error; you should never see this. If you do please contact us.                     |
-|    **580**   | To (oU) User Missing                   | This is an internal error; you should never see this. If you do please contact us.                     |
-|    **580**   | To (fU) User Missing                   | This is an internal error; you should never see this. If you do please contact us.                     |
+|    **401**   | IP Not Authorised| The IP Address doesn't match any account in the system.|
+|**408**| Request Timeout|If the request wasn't answered or wasn't able to get a reply from the other side|
+|**487**| Request Terminated|If the caller closes the phone before connection|
+|**500**| Unidentified Internal Switch| This is an internal error; you should never see this. If you do please contact us.|
+|**500**| Server not accepting calls (Paused)| Either your account or server gets disabled with ConnexCS.|
+|**503**| Unknown User| Username & Passwords don't match to any known user account.|
+|**503**| Unable to perform LRN| You have selected LRN (Location Routing Number) dipping for this route, so it's likely that you don't have credit with us.|
+|**503**| LCR Unavailable| The system is unable to perform a Least Cost Routing (LCR) lookup.|
+|**503**| Blocked by Dial plan| The prefix/number isn't matched by the allowed dial plan.|
+|**503**| No Routes Available (Pre)| No rate card rule to allow the call to progress.|
+|**503**| No Routes Available (U)| No routes are available either due to: Lock, Profit Assurance, Routing Strategy or ScriptForge.|
+|**503**| No Routes Available (Lock)| Locking your Ingress routing has left no routing options.|
+|**503**| No Routes Available (Profit Assurance) | Profit Assurance has left no routing options.|
+|**503**| Dropping Call (Strategy)| Strategic Routing has dropped the call.|
+|**503**| Internal Strategic Routing Error| An error with the config of Strategic Routing.|
+|**580**| No Route Available| The number dialled doesn't match any ingress routing profile.|
+|**580**| Switch IP Variable Not Provided| This is an internal error; you should never see this. If you do please contact us.|
+|**580**| To (oU) User Missing| This is an internal error; you should never see this. If you do please contact us.|
+|**580**| To (fU) User Missing| This is an internal error; you should never see this. If you do please contact us.|
 
 !!! info "End Point synchronisation"
     When making changes, although we try to synchronise all endpoints instantly, as this is a distributed system, it can take up to 60 seconds for any changes to take effect.


### PR DESCRIPTION
## **1. SIP traces**
Here is an example describing a SIP trace:

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE
    Bob-->>Alice: 100 Trying
    Bob-->>Alice: 180 Ringing
    Bob->>Alice: 200 OK (Connected)
    Alice->>Bob: ACK
    Note over Alice,Bob: The call is active
    Alice->>Bob: BYE
    Bob->>Alice: 200 OK
```

Alice and Bob represent the parties on the call. Alice sends an **INVITE** packet to Bob. Then Bob sends a **100 Trying** (provides you the feedback that your request is getting processed by a SIP Application) message together with **180 Ringing** (the Destination User Agent has received the INVITE message and is alerting the user of the call).

Further, **200 OK** is sent which means the calls are connected.

The **ACK** message is sent from Alice to Bob confirming that the call has been connected.

https://bani-certidoc--connexcs-docs.netlify.app/logging/#sip-traces

## **2. Re-transmissions**


Here is an example describing Re-transmissions:

```mermaid
sequenceDiagram
autonumber
rect rgb(127, 0, 255)
rect rgb(100, 180, 255)
rect rgb(252, 110,153)
Alice->>Bob: INVITE (cseq 1)
end
Note over Alice,Bob: 500ms delay
rect rgb(252, 110,153)
Alice->>Bob: INVITE (cseq 1)
end
rect rgb(252, 110,153)
Bob-->>Alice: 100 Trying
end
rect rgb(252, 110,153)
Bob-->>Alice: 180  Ringing
end
rect rgb(252, 110,153)
Bob->>Alice: 200 OK (Connected)
end
rect rgb(252, 110,153)
Alice->>Bob: ACK
end
end
Note over Alice,Bob: The call is active
rect rgb(100, 180, 255)
rect rgb(252, 110,153)
Alice->>Bob: BYE
end
rect rgb(252, 110,153)
Bob->>Alice: 200 OK
end
end
end
```

Alice and Bob represent the parties on the call. Alice sends an INVITE packet to Bob. INVITE is an initial request.

Then Bob sends a 100 Trying (provides you the feedback that your request is getting processed by a SIP Application) message along with 180 Ringing (the Destination User Agent has received the INVITE message and is alerting the user of the call). 100 Trying and 180 Ringing are provisional responses.

The re-invites get absorbed when they're received. When Bob receives the INVITE packet and a special timer is set (please see the below timer table) as to how long it should wait for re-transmissions. If any packet is received within this time frame, the packet gets ignored.

Further, 200 OK is sent which means the calls are connected. 200 OK is a final reply.

The ACK is message is sent from Alice to Bob confirming that the call has been connected.

Each line is a Message.

From 1 message (INVITE) to message 5 (ACK), it's considered as a single Transaction.

Similarly, messages 6 (BYE) and 7 (200 OK) are also considered as a single Transaction.

From message 1 to message 7, the whole conversation is a Dialog.

!!! note "Note"
    Message displayed in Pink color.
    Transaction displayed in Blue color.
    Dialog displayed in Violet color.

https://bani-certidoc--connexcs-docs.netlify.app/logging/#sip-traces


## **3. SIP Pings**

**Case 1: Normal SIP Ping**

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE (cseq 1)
    Bob-->>Alice: 100 Trying
    Bob-->>Alice: 180 Ringing
    Bob->>Alice: 200 OK (Connected)
    Alice->>Bob: ACK
    Note over Alice,Bob: The call is active
    Bob->>Alice: OPTIONS
    Alice->>Bob: 200 OK
    Note over Alice,Bob: The call has ended
    Alice->>Bob: BYE
    Bob->>Alice: 200 OK
```
In this case, Bob sends a message to Alice called **OPTIONS** and Alice sends back **200 OK**. If **200 OK** isn't sent, the call be get disconnected.

**Case 2: Alice Disappears**

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE (cseq 1)
    Bob-->>Alice: 100 Trying
    Bob-->>Alice: 180 Ringing
    Bob->>Alice: 200 OK (Connected)
    Alice->>Bob: ACK
    Note over Alice,Bob: The call is active
    Bob->>Alice: OPTIONS
    Note over Alice,Bob: We did not get a reply, other side disappears 
    Note over Alice,Bob: We will drop the call
    Bob->>Alice: BYE (No SIP Ping Reply)
```

In this case, the call is half-way connected and Alice doesn't reply to the message sent by Bob. Bob decides to drop the call.

If Alice is alive, then you may get a reply, if there is a reply, then this is likely a premature disconnection and there is a fault with the SIP ping on Alice's side.

**Case 3: 3-party Example**

```mermaid
    sequenceDiagram
    autonumber
    Alice->>ConnexCS: INVITE (cseq 1)
    ConnexCS-->>Alice: 100 Trying
    ConnexCS->>Charlie: INVITE (cseq 1)
    Charlie-->>ConnexCS: 100 Trying
    Charlie-->>ConnexCS: 180 Ringing
    ConnexCS-->>Alice: 180 Ringing
    Charlie->>ConnexCS: 200 OK (Connected)
    ConnexCS->>Alice: 200 OK (Connected)
    Alice->>ConnexCS: ACK
    ConnexCS->>Charlie: ACK
    Note over Alice,Charlie: The call is active
    ConnexCS->>Alice: OPTIONS
    Alice->>ConnexCS: 200 OK
    ConnexCS->>Charlie: OPTIONS
    Charlie->>ConnexCS: 200 OK
    Note over Alice,Charlie: Call Disconnects
    Charlie->>ConnexCS: BYE
    ConnexCS->>Alice: BYE
    Alice->>ConnexCS: 200 OK
    ConnexCS->>Charlie: 200 OK
```
In this case, the communication happens between 3 parties. ConnexCs is sending OPTION packets in both the directions (to Alice and Charlie).

**Case 4:Missing SIP Ping Call Disconnection (Charlie disappears)**

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE (cseq 1)
    Bob-->>Alice: 100 Trying
    Bob->>Charlie: INVITE (cseq 1)
    Charlie-->>Bob: 100 Trying
    Charlie-->>Bob: 183 Ringing
    Bob-->>Alice: 183 Ringing
    Charlie->>Bob: 200 OK (Connected)
    Bob->>Alice: 200 OK (Connected)
    Alice->>Bob: ACK
    Bob->>Charlie: ACK
    Note over Alice,Charlie: The call is active
    Bob->>Alice: OPTIONS
    Alice->>Bob: 200 OK
    Bob->>Charlie: OPTIONS
    Note over Alice,Charlie: No reply from Charlie, we need to disconnect
    Bob->>Charlie: BYE
    Bob->>Alice: BYE
    Alice->>Bob: 200 OK
```

In this case, when we send the OPTION packet to Charlie, he doesn't reply. The OPTION message disappears and we need to disconnect the call.

Another scenario is when ConnexCS sends message to Charlie and Charlie is active on the call, he will send a BYE message to Alice and we won't see a reply to that.

https://bani-certidoc--connexcs-docs.netlify.app/customer/auth/#sip-pings

## **4. Re-Invite**

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE (cseq 1)
    Bob-->>Alice: 100 Trying
    Bob->>Charlie: INVITE (cseq 1)
    Charlie-->>Bob: 100 Trying
    Charlie-->>Bob: 180 Ringing
    Bob-->>Alice: 180 Ringing
    Charlie->>Bob: 200 OK (Connected)
    Bob->>Alice: 200 OK (Connected)
    Alice->>Bob: ACK
    Bob->>Charlie: ACK
    Note over Alice,Charlie: The call is active
    Bob->>Alice: REINVITE
    Alice->>Bob: 200 OK
    Bob->>Charlie: REINVITE
    Charlie->>Bob: 200 OK
    Note over Alice,Charlie: Call Disconnects
    Charlie->>Bob: BYE
    Bob->>Alice: BYE
    Alice->>Bob: 200 OK
    Bob->>Charlie: 200 OK
```

In case of a Re-Invite, it re-establishes an entire call.

Here, Alice starts a call with Bob, the call is active without any issues and the media is through UK. But as a provider we detect the call isn't going through UK. Thus, we send the Re-Invite to Alice to send the media through us and we can place the call on a different server in real-time and in the middle of the call. Thus, a Re-Invite can contain some extra information also.

https://bani-certidoc--connexcs-docs.netlify.app/logging/#re-invite

## **5. Various Timers**

```mermaid
     sequenceDiagram
    autonumber
    Alice->>Bob: INVITE
    Note over Alice,Bob: First Reply Timer (500ms)
    Bob-->>Alice: 100 Trying
    Note over Alice,Bob: PDD Timer (5s)
    Bob-->>Alice: 180 Ringing
    Note over Alice,Bob: Ring Timer (30s)
    Bob->>Alice: 200 OK (Connected)
    Alice->>Bob: ACK
    Note over Alice,Bob: Max Call Duration Timer (1 hour)
    Alice->>Bob: BYE
    Bob->>Alice: 200 OK
```

Here, Alice sends an invite to Bob and it's expected to get a reply (100 Trying) within in 500ms which is a **First Reply Timer**.

Then a **PDD timer** is set for 5s to hear the ringing. Post-dial delay (PDD) is the measurement of how long it takes for a calling party to hear a ring-back tone after initiating a call.

The time from when the respondent's phone starts ringing until it's answered; is a **Ring Timer**.

When the call is active **Max Call Duration Timer** comes into the picture. When this timer is active, the active call gets disconnected when it reaches the maximum time of an active call.

https://bani-certidoc--connexcs-docs.netlify.app/logging/#re-transmissions

## **5.  ACK Message**

An ACK is an **Acknowledgement** of a final reply.

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE
    Bob-->>Alice: 100 Trying
    Bob-->>Alice: 180 Ringing
    Bob->>Alice: 200 OK (Connected)
    Alice->>Bob: ACK
    Note over Alice,Bob: The call is active
    Alice->>Bob: BYE
    Bob->>Alice: 200 OK
```

https://bani-certidoc--connexcs-docs.netlify.app/customer/auth/#sip-pings

## **6.  Reasons for Call Disconnection**

Missing ACK: We can if a call gets disconnected within 5 seconds, its because an Acknowledgement wasn't received

Missing SIP Ping: We can if a call gets disconnected within 20-30 seconds, it's because of a missing SIP Ping.

Missing Re-Invite: We can if a call gets disconnected within 5 minutes, it's because of a missing Re-Invite message.

https://bani-certidoc--connexcs-docs.netlify.app/logging/#re-transmissions



## **7. Cancel Message**

**CANCEL** message indicates that the previous request was terminated by user. In this case, the CANCEL message is sent from Alice to Bob.

Cancel can be due to PDD timer is too high or ringing exists for a longer duration.

Bob should send 487 Canceled message to Alice.

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE
    Bob-->>Alice: 100 Trying
    Alice->>Bob: CANCEL (PDD Too High)
    Bob->>Alice: 487 Canceled
    Alice->>Bob: INVITE
    Bob-->>Alice: 100 Trying
    Bob-->>Alice: 180 Ringing
    Alice->>Bob: CANCEL (Alternative, Ringing Too Long)
    Bob->>Alice: 487 Canceled
```

https://bani-certidoc--connexcs-docs.netlify.app/customer/auth/#sip-pings


## **8. SIP Code**

408, 404 and 487

https://bani-certidoc--connexcs-docs.netlify.app/routing/#error-codes

## **9. How to correlate a Reply to an Initial Request**

The correlation of a Reply to an Initial Request can be done when the Invites have the same cseq.

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE (cseq 123)
    Bob-->>Alice: 100 Trying
    Bob-->>Alice: 180 Ringing
    Bob->>Alice: 408 Ring Timeout (cseq 123 INVITE)
```

https://bani-certidoc--connexcs-docs.netlify.app/logging/#sip-traces)

## **10. SIP user auth**

```mermaid
    sequenceDiagram
    autonumber
    Alice->>Bob: INVITE
    Bob-->>Alice: 100 Trying
    Bob->>Alice: 407 Proxy Authentication Required
    Note over Alice,Bob: 407 contains nonce.
    Note left of Alice: HASH(Combine Password + Nonce).
    Alice->>Bob: INVITE (+ Auth Header)
    Bob-->>Alice: 100 Trying
    Note right of Bob: HASH(Combine Password + Nonce).
    Note right of Bob: Compare Hashes - They Match.
    Bob-->>Alice: 183 Ringing
    Bob->>Alice: 200 OK (Connected)
```

For call authentication we should have a Username and a Password. The Username and Password should get to the other side.

The Username is sent on Plain-text and the user (Alice) hashes the password. **407** contains a nonce. A nonce is a random String of which gets send over to Alice. Both Alice and Bob are aware of this random string. Authorization header is sent with the INVITE. Then Bob combines the password with the nonce and compares the nonce. If the hashes match, the call gets connected.

!!! note "407 Proxy Authentication is a part of Challenge-Response and is necessary when you proceed with SIP User Auth. Also you cannot have IP Authentication and SIP Authentication work together"

https://bani-certidoc--connexcs-docs.netlify.app/customer/auth/#sip-user-authentication


## **11. 200 OK Message**

**200 OK** is a Success message. In order to understand how the **200 OK** is related to we need to follow back the original cseq.

For example, if you don't see a 200 OK for a BYE message it means the other side has disappeared.

https://bani-certidoc--connexcs-docs.netlify.app/customer/auth/#sip-user-authentication


## **12. 4xx vs 5xx**

!!! note "4XX vs 5XX"
    4xx codes are Client Failure Responses, while 5XX are Server Failure Responses. 
    For example, it doesn't mean that the server couldn't deliver the call but it means the server knows that the number doesn't exist.

https://bani-certidoc--connexcs-docs.netlify.app/routing/#error-codes