### PR TITLE
Fix duplicate meta titles and descriptions across docs.connexcs.com

### DIFF
--- a/docs/acronyms-and-definitions.md
+++ b/docs/acronyms-and-definitions.md
@@ -1,3 +1,6 @@
+---
+description: Reference glossary of ConnexCS telecom acronyms and definitions, including ASR and NER call-quality calculations used throughout the documentation.
+---
 # Acronyms and Definitions
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/anvil-apps/click-2-dial.md
+++ b/docs/anvil-apps/click-2-dial.md
@@ -1,3 +1,6 @@
+---
+description: Click-2-Dial lets ConnexCS users trigger calls programmatically from an interface instead of manually dialing, routing to an extension or number.
+---
 # Click-2-Dial (Programmatic API Calling)
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/anvil-apps/did-purchase.md
+++ b/docs/anvil-apps/did-purchase.md
@@ -1,3 +1,7 @@
+---
+title: Anvil DID Purchase | Buy Carrier Numbers
+description: The Anvil DID Purchase app lets customers browse and acquire carrier-listed DIDs through ConnexCS, which provides the infrastructure, not the numbers.
+---
 # DID Purchase
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/anvil-apps/peering-hub.md
+++ b/docs/anvil-apps/peering-hub.md
@@ -1,3 +1,6 @@
+---
+description: 'Peering Hub simplifies STIR/SHAKEN setup in ConnexCS: generating keys, requesting iConnectiv (STI-PA) certificates, and signing outbound calls.'
+---
 # Peering Hub
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/anvil-apps/yoco-payments.md
+++ b/docs/anvil-apps/yoco-payments.md
@@ -1,3 +1,6 @@
+---
+description: Integrate Yoco Payments with ConnexCS to collect customer payments programmatically using a Secret API Key for secure, authenticated transactions.
+---
 # Yoco Payment
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/anvil.md
+++ b/docs/anvil.md
@@ -1,3 +1,6 @@
+---
+description: Explore ConnexCS Anvil, the AI-powered app builder that creates professional web applications from natural-language descriptions. Currently in alpha.
+---
 # ConnexCS Anvil (AI App Builder)
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/anyedge/anyedge.md
+++ b/docs/anyedge/anyedge.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS AnyEdge is a distributed load balancer that optimizes call distribution across regions, improving routing efficiency and VoIP availability.
+---
 # AnyEdge
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,7 @@
+---
+title: Platform APIs | REST API Overview & Specifications
+description: Understand the two ConnexCS platform APIs, their distinct URLs, and the shared specification they follow for programmatic control of your softswitch.
+---
 # Application Programming Interface
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/app.md
+++ b/docs/apps/architecture/app.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS App is a container that bundles Button Builder, Database, Domain, Key Value Store, Page Builder, ScriptForge, Templates, and Query Builder.
+---
 # App
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/architecture.md
+++ b/docs/apps/architecture/architecture.md
@@ -1,3 +1,6 @@
+---
+description: 'ConnexCS App Platform architecture: a globally distributed, stateless web server layer served via AnyCast Edge Nodes with automatic failover between nodes.'
+---
 # Architecture
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/button-builder.md
+++ b/docs/apps/architecture/button-builder.md
@@ -1,3 +1,7 @@
+---
+title: Button Builder | App Platform Architecture
+description: Build custom buttons in the ConnexCS App Platform with configurable name, icon, and color, and trigger ScriptForge scripts directly on button click.
+---
 # Button Builder
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/cxC5Server.md
+++ b/docs/apps/architecture/cxC5Server.md
@@ -1,1 +1,5 @@
+---
+title: cxC5Server | ScriptForge Telephony Control API
+description: 'cxC5Server API reference: a ScriptForge telephony control class for real-time call handling, media operations, answering, recording, bridging, and transcription.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxC5Server.md', '') }}

--- a/docs/apps/architecture/cxCallControl.md
+++ b/docs/apps/architecture/cxCallControl.md
@@ -1,1 +1,4 @@
+---
+description: 'cxCallControl API reference: manage call origination, monitoring, and queues on Class 5 systems, SIP registration on Class 4, and AI Agent outbound calls.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxCallControl.md', '') }}

--- a/docs/apps/architecture/cxJob.md
+++ b/docs/apps/architecture/cxJob.md
@@ -1,1 +1,4 @@
+---
+description: 'cxJob API reference: push jobs to the ScriptForge job queue for asynchronous task processing, with progress tracking and result retrieval.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxJob.md', '') }}

--- a/docs/apps/architecture/cxKV.md
+++ b/docs/apps/architecture/cxKV.md
@@ -1,1 +1,4 @@
+---
+description: 'cxKV API reference: a globally synchronized key-value store with atomic operations, increments, expiration, and quota management for ScriptForge apps.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxKV.md', '') }}

--- a/docs/apps/architecture/cxKysely.md
+++ b/docs/apps/architecture/cxKysely.md
@@ -1,1 +1,4 @@
+---
+description: 'cxKysely API reference: a Kysely dialect for querying ConnexCS databases from ScriptForge, with connection management and transaction handling.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxKysely.md', '') }}

--- a/docs/apps/architecture/cxMcpServer.md
+++ b/docs/apps/architecture/cxMcpServer.md
@@ -1,1 +1,4 @@
+---
+description: 'cxMcpServer API reference: a Model Context Protocol implementation for building AI-tool integration servers with custom tools and data resources.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxMcpServer.md', '') }}

--- a/docs/apps/architecture/cxPubSub.md
+++ b/docs/apps/architecture/cxPubSub.md
@@ -1,1 +1,4 @@
+---
+description: 'cxPubSub API reference: a global Publish/Subscribe messaging bus for real-time, event-driven communication between ScriptForge app components.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxPubSub.md', '') }}

--- a/docs/apps/architecture/cxRegistry.md
+++ b/docs/apps/architecture/cxRegistry.md
@@ -1,1 +1,4 @@
+---
+description: 'cxRegistry API reference: a project-scoped, optionally encrypted key-value store for persisting data across ScriptForge script executions and secrets.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxRegistry.md', '') }}

--- a/docs/apps/architecture/cxRest.md
+++ b/docs/apps/architecture/cxRest.md
@@ -1,1 +1,4 @@
+---
+description: 'cxRest API reference: an authenticated HTTP client for GET, POST, PUT, and DELETE calls across the full ConnexCS REST API from ScriptForge apps.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxRest.md', '') }}

--- a/docs/apps/architecture/cxRouter.md
+++ b/docs/apps/architecture/cxRouter.md
@@ -1,1 +1,4 @@
+---
+description: 'cxRouter API reference: run Hono web routers inside the ScriptForge sandbox by converting serialized requests into Web Request objects and back.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxRouter.md', '') }}

--- a/docs/apps/architecture/cxSend.md
+++ b/docs/apps/architecture/cxSend.md
@@ -1,1 +1,4 @@
+---
+description: 'cxSend API reference: asynchronously queue email and SMS messages for delivery through a job-based sending system in ConnexCS ScriptForge apps.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxSend.md', '') }}

--- a/docs/apps/architecture/cxUserspace.md
+++ b/docs/apps/architecture/cxUserspace.md
@@ -1,1 +1,4 @@
+---
+description: 'cxUserspace API reference: create, read, update, and delete userspace datastore records via simple CRUD methods or advanced Knex-based queries.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxUserspace.md', '') }}

--- a/docs/apps/architecture/cxWebSocket.md
+++ b/docs/apps/architecture/cxWebSocket.md
@@ -1,1 +1,4 @@
+---
+description: 'cxWebSocket API reference: send data, listen for events, and manage the connection lifecycle for real-time bidirectional WebSocket communication.'
+---
 {{ external_markdown('https://cdn.cnxcdn.com/scriptforge-api-docs/api/cxWebSocket.md', '') }}

--- a/docs/apps/architecture/database.md
+++ b/docs/apps/architecture/database.md
@@ -1,3 +1,6 @@
+---
+description: Create custom persistent data storage in the ConnexCS App Platform, scoped per customer or global, for lookups, caching, or stateful applications.
+---
 # Database
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/domain.md
+++ b/docs/apps/architecture/domain.md
@@ -1,3 +1,6 @@
+---
+description: Set the public domain where your ConnexCS App Platform applications are visible and accessible, including the free default cnx.page domain.
+---
 # Domain
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/environmental-variables.md
+++ b/docs/apps/architecture/environmental-variables.md
@@ -1,3 +1,6 @@
+---
+description: Define Environmental Variables in the ConnexCS App Platform, accessible from ScriptForge, Templates, Pages, and Button Builder via this.env.
+---
 # Environmental Variables
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/key-value.md
+++ b/docs/apps/architecture/key-value.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Key-Value Store is a simple, efficient key-value database for the App Platform, storing data as unique key and value pairs.
+---
 # Key Value Store
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/livetranscription.md
+++ b/docs/apps/architecture/livetranscription.md
@@ -1,3 +1,6 @@
+---
+description: Stream real-time call transcripts over WebSocket in ConnexCS, delivering transcription events instantly to external systems as calls happen.
+---
 # Live transcription via WebSocket
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/project.md
+++ b/docs/apps/architecture/project.md
@@ -1,3 +1,6 @@
+---
+description: A ConnexCS Project organizes App Platform applications under one umbrella; every published application must be linked to a project for tracking.
+---
 # Project
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/pub-sub.md
+++ b/docs/apps/architecture/pub-sub.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Pub/Sub Bus enables asynchronous messaging between app components, illustrated with a server-side chat application example.
+---
 # Pub/Sub Bus
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/query-builder.md
+++ b/docs/apps/architecture/query-builder.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Query Builder is an abstraction layer for constructing database queries without writing raw SQL, built for the App Platform.
+---
 # Query Builder
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/scriptforge-migration.md
+++ b/docs/apps/architecture/scriptforge-migration.md
@@ -1,3 +1,6 @@
+---
+description: Migrate ConnexCS ScriptForge scripts from the old documentation pattern to the new implementation, with example code changes for cxC5Server.
+---
 # ConnexCS ScriptForge Migration Guide: Old to New Implementation
 
 ## Overview

--- a/docs/apps/architecture/scriptforge.md
+++ b/docs/apps/architecture/scriptforge.md
@@ -1,3 +1,7 @@
+---
+title: ScriptForge (FaaS) | App Platform Scripting Engine
+description: ScriptForge is the Functions-as-a-Service scripting engine behind the ConnexCS App Platform, giving developers a full API for building app logic.
+---
 # ScriptForge (FaaS)
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/architecture/template.md
+++ b/docs/apps/architecture/template.md
@@ -1,3 +1,6 @@
+---
+description: Use ConnexCS Templates to customize outbound email, SMS, Customer Portal, and WebPhone content with a powerful communication templating system.
+---
 # Template
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/alert.md
+++ b/docs/apps/components/alert.md
@@ -1,3 +1,7 @@
+---
+title: Alert Component | App Platform Page Builder
+description: The Alert component in the ConnexCS App Platform displays success, warning, info, or error boxes as modal dialogs that stay visible until dismissed.
+---
 # Alert
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/button.md
+++ b/docs/apps/components/button.md
@@ -1,3 +1,6 @@
+---
+description: The Button component in the ConnexCS App Platform triggers events on click, commonly used to submit forms, navigate pages, or run actions.
+---
 # Button
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/card.md
+++ b/docs/apps/components/card.md
@@ -1,3 +1,6 @@
+---
+description: The Card component in the ConnexCS Page Builder groups related form fields into a container for a more organized, visually appealing layout.
+---
 # Card
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/cascader.md
+++ b/docs/apps/components/cascader.md
@@ -1,3 +1,6 @@
+---
+description: The Cascader (Cascade Select) component lets users navigate a hierarchical set of options, narrowing choices based on previous selections in a form.
+---
 # Cascader
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/chart.md
+++ b/docs/apps/components/chart.md
@@ -1,3 +1,6 @@
+---
+description: The Chart component in the ConnexCS Page Builder renders bar, line, area, and pie charts for dashboards, web analytics, and financial reporting.
+---
 # Chart
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/checkbox.md
+++ b/docs/apps/components/checkbox.md
@@ -1,3 +1,6 @@
+---
+description: The Checkbox component in the ConnexCS Page Builder lets users select multiple options from a set of choices, ideal for preference-based forms.
+---
 # Checkbox
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/collapse.md
+++ b/docs/apps/components/collapse.md
@@ -1,3 +1,6 @@
+---
+description: The Collapse component organizes lengthy or complex ConnexCS forms into expandable sections, reducing clutter and improving navigation.
+---
 # Collapse
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/color.md
+++ b/docs/apps/components/color.md
@@ -1,3 +1,6 @@
+---
+description: The Color component in the ConnexCS Page Builder lets users pick a color from a palette or enter a color code for design and formatting fields.
+---
 # Color
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/data-grid.md
+++ b/docs/apps/components/data-grid.md
@@ -1,3 +1,6 @@
+---
+description: The Data Grid component displays and edits tabular data in ConnexCS apps, with inline editing, sorting, filtering, and pagination built in.
+---
 # Data Grid
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/date.md
+++ b/docs/apps/components/date.md
@@ -1,3 +1,7 @@
+---
+title: Date Component | App Platform Page Builder
+description: The Date component in the ConnexCS Page Builder provides a calendar-style date picker interface for selecting dates within forms and apps.
+---
 # Date
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/dialog.md
+++ b/docs/apps/components/dialog.md
@@ -1,3 +1,6 @@
+---
+description: The Dialog component creates modal windows or pop-up forms inside a larger ConnexCS form, collecting extra input without disrupting the main flow.
+---
 # Dialog
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/divider.md
+++ b/docs/apps/components/divider.md
@@ -1,3 +1,6 @@
+---
+description: The Divider component visually separates sections of a ConnexCS form, improving readability by marking where different sections begin and end.
+---
 # Divider
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/editor.md
+++ b/docs/apps/components/editor.md
@@ -1,3 +1,6 @@
+---
+description: The Editor component in the ConnexCS App Platform lets you build web content for rapid prototyping, CMS pages, email marketing, and static sites.
+---
 # Editor
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/grid.md
+++ b/docs/apps/components/grid.md
@@ -1,3 +1,6 @@
+---
+description: The Grid component displays and organizes data in rows and columns within a ConnexCS form, with each cell holding a data element or input field.
+---
 # Grid
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/group.md
+++ b/docs/apps/components/group.md
@@ -1,3 +1,7 @@
+---
+title: Group Component | App Platform Page Builder
+description: The Group component logically groups related fields in a ConnexCS form, giving it visual structure so users understand how fields relate.
+---
 # Group
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/html.md
+++ b/docs/apps/components/html.md
@@ -1,3 +1,6 @@
+---
+description: The HTML component in the ConnexCS Page Builder renders custom markup, with setHTML and set Template used to populate content via Handlebars.
+---
 # HTML
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/iframe.md
+++ b/docs/apps/components/iframe.md
@@ -1,3 +1,6 @@
+---
+description: The I-Frame component embeds an external web page, such as a map, calendar, or payment gateway, inside a ConnexCS form without breaking its layout.
+---
 # I-Frame
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/inline.md
+++ b/docs/apps/components/inline.md
@@ -1,3 +1,6 @@
+---
+description: The Inline layout in the ConnexCS Page Builder arranges form elements compactly for a more organized, responsive, and legible form design.
+---
 # Inline
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/input.md
+++ b/docs/apps/components/input.md
@@ -1,3 +1,6 @@
+---
+description: The Input component in the ConnexCS Page Builder is the core text field for entering and displaying data within forms and applications.
+---
 # Input
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/link.md
+++ b/docs/apps/components/link.md
@@ -1,3 +1,6 @@
+---
+description: The Link component in the ConnexCS Page Builder opens external resources, navigates form sections, triggers actions, or shows contextual help.
+---
 # Link
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/number.md
+++ b/docs/apps/components/number.md
@@ -1,3 +1,6 @@
+---
+description: The Number component in the ConnexCS Page Builder collects quantitative data with validation, spinners, and range-slider input options.
+---
 # Number
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/page-layout.md
+++ b/docs/apps/components/page-layout.md
@@ -1,3 +1,6 @@
+---
+description: Page Layout is the skeleton that arranges form elements in the ConnexCS Page Builder, determining the placement, size, and spacing of each part.
+---
 # Page Layout
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/pagination.md
+++ b/docs/apps/components/pagination.md
@@ -1,3 +1,6 @@
+---
+description: Pagination in the ConnexCS Page Builder splits large lists of items across pages, avoiding an endless scroll through catalogs or option sets.
+---
 # Pagination
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/portal.md
+++ b/docs/apps/components/portal.md
@@ -1,3 +1,7 @@
+---
+title: Portal Component | App Platform Page Builder
+description: The Portal component in the ConnexCS Page Builder is a programmatic layout element for loading and displaying multiple pages on demand.
+---
 # Portal
 
 ## Description

--- a/docs/apps/components/radio.md
+++ b/docs/apps/components/radio.md
@@ -1,3 +1,6 @@
+---
+description: The Radio component in the ConnexCS Page Builder presents a group of options where users can select only one, like a set of mutually exclusive switches.
+---
 # Radio
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/rate.md
+++ b/docs/apps/components/rate.md
@@ -1,3 +1,6 @@
+---
+description: The Rate component in the ConnexCS Page Builder lets users express satisfaction or preference on a visual scale, useful for feedback and surveys.
+---
 # Rate
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/select.md
+++ b/docs/apps/components/select.md
@@ -1,3 +1,6 @@
+---
+description: The Select component in the ConnexCS Page Builder is a dropdown menu for choosing one option from a predefined list of choices.
+---
 # Select
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/slider.md
+++ b/docs/apps/components/slider.md
@@ -1,3 +1,6 @@
+---
+description: The Slider component in the ConnexCS Page Builder lets users drag a handle along a bar to visually select a numerical value in a set range.
+---
 # Slider
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/statistic.md
+++ b/docs/apps/components/statistic.md
@@ -1,3 +1,6 @@
+---
+description: The Statistic component highlights a number or figure, such as a value, amount, or ranking, with optional countdown and card-style display.
+---
 # Statistic
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/steps.md
+++ b/docs/apps/components/steps.md
@@ -1,3 +1,6 @@
+---
+description: The Steps component guides users through a complex process by breaking it into stages, visually indicating progress in a ConnexCS form.
+---
 # Steps
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/sub-form+.md
+++ b/docs/apps/components/sub-form+.md
@@ -1,3 +1,6 @@
+---
+description: Sub-Form+ is a complex, nestable layout component for list (array) form data in the ConnexCS Page Builder, supporting multi-level nesting.
+---
 # Sub-Form+
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/sub-form.md
+++ b/docs/apps/components/sub-form.md
@@ -1,3 +1,6 @@
+---
+description: The Sub-Form component embeds one form inside another in the ConnexCS Page Builder, capturing extra details for a specific section.
+---
 # Sub-Form
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/switch.md
+++ b/docs/apps/components/switch.md
@@ -1,3 +1,6 @@
+---
+description: The Switch component in the ConnexCS Page Builder toggles a field between on and off states, offering a clear binary choice in a form.
+---
 # Switch
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/table.md
+++ b/docs/apps/components/table.md
@@ -1,3 +1,6 @@
+---
+description: The Table component in the ConnexCS Page Builder presents data in rows and columns while streamlining data entry and improving form usability.
+---
 # Table
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/tabs.md
+++ b/docs/apps/components/tabs.md
@@ -1,3 +1,6 @@
+---
+description: The Tabs component organizes a ConnexCS form into multiple sections within one interface, breaking complex tasks into logical, manageable chunks.
+---
 # Tabs
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/text-area.md
+++ b/docs/apps/components/text-area.md
@@ -1,3 +1,6 @@
+---
+description: The Text-Area component in the ConnexCS Page Builder captures multi-line free text, ideal for feedback, support requests, and open-ended answers.
+---
 # Text Area
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/text.md
+++ b/docs/apps/components/text.md
@@ -1,3 +1,6 @@
+---
+description: The Text component in the ConnexCS Page Builder is a single-line field for entering text, numbers, or symbols as core form input.
+---
 # Text
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/time.md
+++ b/docs/apps/components/time.md
@@ -1,3 +1,6 @@
+---
+description: The Time component in the ConnexCS Page Builder captures specific times for appointments, event registration, scheduling, and recurring reminders.
+---
 # Time
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/transfer.md
+++ b/docs/apps/components/transfer.md
@@ -1,3 +1,6 @@
+---
+description: The Transfer component lets users move items between two lists in a ConnexCS form, useful for selections, assignments, and content filtering.
+---
 # Transfer
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/tree-select.md
+++ b/docs/apps/components/tree-select.md
@@ -1,3 +1,6 @@
+---
+description: Tree-Select organizes dropdown options into parent-child categories in the ConnexCS Page Builder, letting users navigate nested choices.
+---
 # Tree-Select
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/components/webphone.md
+++ b/docs/apps/components/webphone.md
@@ -1,3 +1,6 @@
+---
+description: The Webphone component drops a no-code softphone into a ConnexCS app, with full functionality also exposed via API and Environmental Variables.
+---
 # Webphone
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/contact.md
+++ b/docs/apps/contact.md
@@ -1,3 +1,6 @@
+---
+description: 'Install the Contact Center App from the ConnexCS App Store: log in to the Control Panel and navigate to Setup, App Store to begin setup.'
+---
 ## Contact Center Setup & Usage Guide
 
 ### Step-I: Install Contact Center App

--- a/docs/apps/features.md
+++ b/docs/apps/features.md
@@ -1,2 +1,5 @@
+---
+description: Overview of ConnexCS App Platform features for building custom applications, components, and workflows. Full documentation is coming soon.
+---
 !!! warning
     *Documentation coming soon...!!!!*

--- a/docs/apps/introduction.md
+++ b/docs/apps/introduction.md
@@ -1,3 +1,7 @@
+---
+title: App Platform Introduction | ConnexCS
+description: Introduction to the ConnexCS App Platform, part of a telecom platform covering call routing, billing, security, and analytics for carriers.
+---
 # Introduction
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/page-builder.md
+++ b/docs/apps/page-builder.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Page Builder lets you design forms and pages with drag-and-drop components and minimal code, accessible to non-technical users.
+---
 # Page Builder
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/apps/use-case.md
+++ b/docs/apps/use-case.md
@@ -1,3 +1,6 @@
+---
+description: 'Use cases for the ConnexCS App Platform: admin panels, customer-facing panels, agent and call center WebPhones, autonomous calling, and more.'
+---
 # Use Cases
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/billing-basics.md
+++ b/docs/billing-basics.md
@@ -27,7 +27,7 @@ Breakout Reports update in real time and are consistency-checked every 24 hours.
 
 - Bill from CDR data, not from balance changes.
 - Wherever possible, export CDR data at least 24 hours after the final day of the billing period to ensure all records are fully processed.
-- Calculate the cost for each individual call separately, then sum the results. Do not multiply total minutes by a rate — this produces incorrect totals. See [Why Minutes × Rate ≠ Invoice Total](#why-minutes-x-cost-per-minute-is-not-the-same-as-what-the-totals-say) below.
+- Calculate the cost for each individual call separately, then sum the results. Do not multiply total minutes by a rate — this produces incorrect totals. See [Why Minutes × Rate ≠ Invoice Total](#why-minutes-cost-per-minute-invoice-total) below.
 
 ---
 

--- a/docs/billing-basics.md
+++ b/docs/billing-basics.md
@@ -1,3 +1,6 @@
+---
+description: 'Learn ConnexCS billing fundamentals: how account balance updates, why CDRs are the source of truth for charges, and how Breakout Reports stay consistent.'
+---
 # Billing Basics
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,3 +1,6 @@
+---
+description: Compare per-channel and per-minute billing models in ConnexCS, including how channel-based and usage-based charges are calculated and deducted.
+---
 # Billing
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/calling-card.md
+++ b/docs/calling-card.md
@@ -1,3 +1,6 @@
+---
+description: Set up Pinless Calling Cards in ConnexCS. Learn how CLI-based verification lets callers dial in via DID without a PIN, using IVR to route destinations.
+---
 # Pinless Calling Cards
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier.md
+++ b/docs/carrier.md
@@ -1,3 +1,6 @@
+---
+description: Overview of the ConnexCS Carrier interface for managing termination and origination carriers, including credit, authentication, and response handling.
+---
 # Carrier
 
 **Management :material-menu-right: Carrier**

--- a/docs/carrier/carrier-alerts.md
+++ b/docs/carrier/carrier-alerts.md
@@ -1,3 +1,7 @@
+---
+title: Carrier Alerts | Failover Threshold Notifications
+description: Set up Carrier Alerts in ConnexCS to email a chosen address when Consecutive Failovers hit a defined limit, catching carrier issues early.
+---
 # Alerts
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-auth.md
+++ b/docs/carrier/carrier-auth.md
@@ -1,3 +1,7 @@
+---
+title: Carrier Authentication | IP & Credential Setup
+description: Configure Carrier Authentication in ConnexCS with IP-based access rules or username/password credentials for outbound connections to carriers.
+---
 # Auth
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-cdr.md
+++ b/docs/carrier/carrier-cdr.md
@@ -1,3 +1,7 @@
+---
+title: Carrier CDR | Call Detail Records & Billing Data
+description: View Carrier Call Detail Records (CDR) in ConnexCS for billing data like call duration and destination, plus a Global CDR view across all carriers.
+---
 # Call Detail Record
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-custom-reports.md
+++ b/docs/carrier/carrier-custom-reports.md
@@ -1,3 +1,7 @@
+---
+title: Carrier Custom Reports | ASR & Route Analytics
+description: Generate carrier-specific Custom Reports in ConnexCS for granular call performance and quality metrics, including Answer-Seizure Ratio per route.
+---
 # Custom Reports
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-did-inventory.md
+++ b/docs/carrier/carrier-did-inventory.md
@@ -1,3 +1,6 @@
+---
+description: Manage the Carrier DID Inventory in ConnexCS for numbers held by the provider that aren't yet assigned to any specific customer.
+---
 # DID Inventory
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-did.md
+++ b/docs/carrier/carrier-did.md
@@ -1,3 +1,7 @@
+---
+title: Carrier DID | Direct Inward Dial Numbers
+description: View and add Direct Inward Dial (DID) numbers belonging to a carrier in ConnexCS, the provider-side counterpart to Customer DID management.
+---
 # Direct Inward Dial
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-failover.md
+++ b/docs/carrier/carrier-failover.md
@@ -1,3 +1,6 @@
+---
+description: Review the Carrier Failover report in ConnexCS to see calls that failed on one carrier and connected through another, a possible sign of FAS activity.
+---
 # Failover
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-latest-calls.md
+++ b/docs/carrier/carrier-latest-calls.md
@@ -1,3 +1,7 @@
+---
+title: Carrier Latest Calls | Recent Call Monitoring
+description: Monitor a carrier's most recent calls in ConnexCS, including SIP traces and simulated call runs, from the Latest Calls tab or the Logging section.
+---
 # Latest Calls
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-main.md
+++ b/docs/carrier/carrier-main.md
@@ -1,3 +1,7 @@
+---
+title: Carrier Main | Contacts, Rates & Configuration
+description: Configure a Carrier's core settings in ConnexCS, including support contacts, associated Rate Cards, and code-level configuration for the provider.
+---
 # Main
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-payment.md
+++ b/docs/carrier/carrier-payment.md
@@ -1,3 +1,7 @@
+---
+title: Carrier Payments | Record & Track Carrier Billing
+description: Record and track payments made to carriers in ConnexCS. Add new carrier payments and review a full payment history from a single tab.
+---
 # Payment
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-reply-management.md
+++ b/docs/carrier/carrier-reply-management.md
@@ -1,3 +1,6 @@
+---
+description: Use Carrier Reply Management in ConnexCS to customize responses to SIP codes 100-606 from a carrier, tailoring messaging for switches with strict requirements.
+---
 # Reply Management
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/carrier/carrier-stats.md
+++ b/docs/carrier/carrier-stats.md
@@ -1,3 +1,7 @@
+---
+title: Carrier Stats | Performance & Traffic Graphs
+description: View carrier-related statistics graphs in ConnexCS, covering the same metrics documented in Customer Stats but scoped to a single carrier.
+---
 # Stats
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/changing-language.md
+++ b/docs/changing-language.md
@@ -1,3 +1,6 @@
+---
+description: Change the display language of the ConnexCS Control Panel user interface, and learn which parts of the UI are and aren't affected by the setting.
+---
 # User Interface Display Language
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/changing-password.md
+++ b/docs/changing-password.md
@@ -1,3 +1,6 @@
+---
+description: Step-by-step guide to changing your ConnexCS Control Panel password, including what you need on hand before starting the password change process.
+---
 # Changing your Password
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/circuit-test.md
+++ b/docs/circuit-test.md
@@ -1,3 +1,6 @@
+---
+description: Run a ConnexCS Circuit Test to troubleshoot calls using FAS, MOS, jitter, packet loss, and answer delay metrics, and review a history of past tests.
+---
 # Circuit Test
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/ai-agent.md
+++ b/docs/class5/ai-agent.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS AI Call Center Agents deliver instant, 24/7 automated support, handling repetitive inquiries at scale without human intervention.
+---
 # AI Agent
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/apps.md
+++ b/docs/class5/apps.md
@@ -1,3 +1,6 @@
+---
+description: Build drag-and-drop Class 5 Apps and ConneXML applications in ConnexCS, such as Echo Tests, Conferences, and IVR setups, in a few clicks.
+---
 # Apps
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/call-center.md
+++ b/docs/class5/call-center.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Call Center module routes inbound calls through configurable queues to agents, with full visibility into queues and live calls.
+---
 # Call Center
 
 <details>

--- a/docs/class5/class5-intro.md
+++ b/docs/class5/class5-intro.md
@@ -1,3 +1,7 @@
+---
+title: Class 5 Overview | PBX & Softswitch Services
+description: Introduction to ConnexCS Class 5 services and PBX features, explained alongside Class 4 softswitch routing to highlight the key differences.
+---
 # Class 5
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/connexml.md
+++ b/docs/class5/connexml.md
@@ -1,3 +1,6 @@
+---
+description: ConneXML is the ConnexCS instruction set for Class 5 Applications, defining what happens when an incoming call hits a customer's DID.
+---
 # ConneXML
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/creating-conference.md
+++ b/docs/class5/creating-conference.md
@@ -1,3 +1,7 @@
+---
+title: Conference Calls | Class 5 Bridge Setup
+description: Set up Conference Calls in ConnexCS Class 5 to let multiple callers join a moderated voice call, configured per customer under Class5 settings.
+---
 # Conference Calls
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/creating-group.md
+++ b/docs/class5/creating-group.md
@@ -1,3 +1,6 @@
+---
+description: Create Groups (Call Queues) in ConnexCS Class 5 to route calls to a team of agents on a FIFO basis, based on your configured routing strategy.
+---
 # Groups
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/creating-ivr.md
+++ b/docs/class5/creating-ivr.md
@@ -1,3 +1,7 @@
+---
+title: IVR Setup | Interactive Voice Response Menus
+description: Build an Interactive Voice Response (IVR) phone tree in ConnexCS Class 5, routing callers to SIP addresses, PSTN numbers, groups, or other IVRs.
+---
 # Interactive Voice Response
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/knowledge-base.md
+++ b/docs/class5/knowledge-base.md
@@ -1,3 +1,6 @@
+---
+description: Upload and index documents in the ConnexCS Class 5 Knowledge Base so AI agents and internal systems can reference RFCs, manuals, and guides in real time.
+---
 # Knowledge Base
 
 <details>

--- a/docs/class5/phonebook.md
+++ b/docs/class5/phonebook.md
@@ -1,3 +1,6 @@
+---
+description: Set up a Class 5 Phonebook in ConnexCS, an internal company directory per customer that stays private to that customer's own users.
+---
 # Phonebook
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/class5/voicemail.md
+++ b/docs/class5/voicemail.md
@@ -1,3 +1,6 @@
+---
+description: View all Voicemail on the ConnexCS system in the Class 5 module, or manage voicemail settings for an individual customer's account.
+---
 # Voicemail
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/cliterminal.md
+++ b/docs/cliterminal.md
@@ -1,3 +1,6 @@
+---
+description: Use the ConnexCS Terminal, a built-in command-line interface in the Control Panel, to run ConnexCS CLI commands without leaving the web interface.
+---
 # ConnexCS Terminal
 
 <details>

--- a/docs/connexamine.md
+++ b/docs/connexamine.md
@@ -1,3 +1,6 @@
+---
+description: ConnExamine watches outbound SIP INVITEs to diagnose call setup delays and failures, measuring response, ringing, and answer times on PBXs and gateways.
+---
 # Connexamine
 
 <details>

--- a/docs/credit-control.md
+++ b/docs/credit-control.md
@@ -1,3 +1,6 @@
+---
+description: Configure the ConnexCS Debit Limit to control Pre-Pay and Post-Pay customer accounts, setting how far a balance can drop before calls are stopped.
+---
 # Credit Control
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-alert.md
+++ b/docs/customer-portal/cp-alert.md
@@ -1,3 +1,7 @@
+---
+title: Portal Alerts | Balance & Account Notifications
+description: View automated Alerts in the ConnexCS Customer Portal for real-time account status insight, including balance notifications and thresholds.
+---
 # Alerts
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-audio.md
+++ b/docs/customer-portal/cp-audio.md
@@ -1,3 +1,6 @@
+---
+description: Upload and manage audio files in the ConnexCS Customer Portal for PBX functions like IVR prompts and Queue hold music, ready for reuse.
+---
 # Audio
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-authentication.md
+++ b/docs/customer-portal/cp-authentication.md
@@ -1,3 +1,6 @@
+---
+description: Configure Authentication in the ConnexCS Customer Portal using IP or SIP username/password credentials to verify calls from a trusted source.
+---
 # Authentication (Auth)
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-breakout.md
+++ b/docs/customer-portal/cp-breakout.md
@@ -1,3 +1,6 @@
+---
+description: View the Breakout Report in the ConnexCS Customer Portal, showing billing-accurate customer activity derived directly from processed CDR data.
+---
 # Breakout
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-cc-agent-dialer-guide.md
+++ b/docs/customer-portal/cp-cc-agent-dialer-guide.md
@@ -1,3 +1,6 @@
+---
+description: Agent Dialer Guide for ConnexCS Contact Center Auto Dialer and Preview Dialer campaigns, covering login, campaign selection, and call controls.
+---
 # Agent Dialer Guide
 
 ---

--- a/docs/customer-portal/cp-cc-campaign.md
+++ b/docs/customer-portal/cp-cc-campaign.md
@@ -1,3 +1,6 @@
+---
+description: Create and configure Contact Center Campaigns in the ConnexCS Customer Portal to manage calling activity, agent performance, and lead engagement.
+---
 # Campaign Creation
 
 ---

--- a/docs/customer-portal/cp-cc-creating-agents.md
+++ b/docs/customer-portal/cp-cc-creating-agents.md
@@ -1,3 +1,6 @@
+---
+description: Create Agents for Auto Dialer and Preview Dialer campaigns in the ConnexCS Contact Center, setting how many agents are assigned per campaign.
+---
 # Creating Agents
 
 ---

--- a/docs/customer-portal/cp-cc-creating-leadsets.md
+++ b/docs/customer-portal/cp-cc-creating-leadsets.md
@@ -1,3 +1,6 @@
+---
+description: Create Leadsets in the ConnexCS Contact Center to organize the contacts and prospects that agents will call during a campaign.
+---
 # Creating Leadsets
 
 ---

--- a/docs/customer-portal/cp-cc-creating-scripts.md
+++ b/docs/customer-portal/cp-cc-creating-scripts.md
@@ -1,3 +1,6 @@
+---
+description: Create call Scripts for Auto Dialer and Preview Dialer campaigns in the ConnexCS Contact Center, guiding agents through customer interactions.
+---
 # Creating Scripts
 
 ---

--- a/docs/customer-portal/cp-cc-dialer-dashboard.md
+++ b/docs/customer-portal/cp-cc-dialer-dashboard.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Contact Center Dialer Dashboard gives real-time insight into campaign activity, agent status, and remaining data during a dialer run.
+---
 # Dialer Dashboard: Features and Functions
 
 ---

--- a/docs/customer-portal/cp-cc-install.md
+++ b/docs/customer-portal/cp-cc-install.md
@@ -1,3 +1,6 @@
+---
+description: Install the Contact Center app from the ConnexCS App Store, selecting User API, Class 5 Server, and Class 4 Server to complete setup.
+---
 # Contact Center Setup & Usage Guide
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-cc-setting-up-dialer.md
+++ b/docs/customer-portal/cp-cc-setting-up-dialer.md
@@ -1,3 +1,7 @@
+---
+title: Dialer Setup Introduction | Contact Center
+description: Set up the ConnexCS Contact Center Dialer end to end, from creating campaigns and agents to preparing scripts and lead sets for outbound calling.
+---
 # Setting Up the Dialer
 
 ---

--- a/docs/customer-portal/cp-cdr.md
+++ b/docs/customer-portal/cp-cdr.md
@@ -1,3 +1,7 @@
+---
+title: Portal CDR | Call Detail Record Viewer
+description: View Call Detail Records (CDR) in the ConnexCS Customer Portal, capturing call duration and destination data for billing and reporting.
+---
 # Call Detail Record
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-con-center.md
+++ b/docs/customer-portal/cp-con-center.md
@@ -1,3 +1,6 @@
+---
+description: Landing page for the ConnexCS Customer Portal Contact Center, linking to the Introduction overview and the full setup and usage guide.
+---
 # Contact Center
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-conference.md
+++ b/docs/customer-portal/cp-conference.md
@@ -1,3 +1,7 @@
+---
+title: Portal Conference | PBX Bridge Calls
+description: Manage Conference Call bridges in the ConnexCS Customer Portal, letting several callers join a moderated voice call, with a view of all groups.
+---
 # Conference
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-contact-center.md
+++ b/docs/customer-portal/cp-contact-center.md
@@ -1,3 +1,7 @@
+---
+title: Contact Center Introduction | Dialer Solution
+description: Introduction to the ConnexCS Dialer, a full contact center solution with a Dialer Dashboard, Agent Management, Campaigns, and Lead Management.
+---
 # Contact Center
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-contracts.md
+++ b/docs/customer-portal/cp-contracts.md
@@ -1,3 +1,7 @@
+---
+title: Portal Contracts | Approval Status Tracking
+description: Track Contracts in the ConnexCS Customer Portal, including name, creation date, and approval status, with alerts for unapproved agreements.
+---
 # Contracts
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-dashboard.md
+++ b/docs/customer-portal/cp-dashboard.md
@@ -1,3 +1,7 @@
+---
+title: Portal Dashboard | Account Activity Overview
+description: The ConnexCS Customer Portal Dashboard gives a quick overview of account activity and call statistics, plus access to configuration and real-time testing.
+---
 # Dashboard
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-data-management.md
+++ b/docs/customer-portal/cp-data-management.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Customer Portal Database feature provides custom persistent data storage for number lookups, caching, and stateful applications.
+---
 # Database
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-dialogs.md
+++ b/docs/customer-portal/cp-dialogs.md
@@ -1,3 +1,7 @@
+---
+title: Portal Dialogs | Active Call View
+description: View active calls in the ConnexCS Customer Portal Dialogs tab, including the Ended status shown while a call finishes tearing down for billing.
+---
 # Dialogs
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-did-purchase.md
+++ b/docs/customer-portal/cp-did-purchase.md
@@ -1,3 +1,7 @@
+---
+title: Portal DID Purchase | Search & Buy Numbers
+description: Search, price, and buy DID numbers directly in the ConnexCS Customer Portal by prefix or area code, with cart checkout and carrier-set pricing.
+---
 # DID Purchase
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-did.md
+++ b/docs/customer-portal/cp-did.md
@@ -1,3 +1,7 @@
+---
+title: Portal DID | Direct Inward Dial Management
+description: Manage Direct Inward Dial (DID) numbers in the ConnexCS Customer Portal, routing inbound public network calls straight to their destination.
+---
 # Direct Inward Dial
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-documents.md
+++ b/docs/customer-portal/cp-documents.md
@@ -1,3 +1,7 @@
+---
+title: Portal Documents | Account File Repository
+description: View all Documents associated with your account in the ConnexCS Customer Portal, including feature lists and payment requirement files.
+---
 # Documents
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-group.md
+++ b/docs/customer-portal/cp-group.md
@@ -1,3 +1,7 @@
+---
+title: Portal Group | Hunt Groups & Call Queues
+description: Create Hunt Groups and Queues in the ConnexCS Customer Portal to route calls to a team, such as Technical Support or Sales, by routing strategy.
+---
 # Group
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-invoice.md
+++ b/docs/customer-portal/cp-invoice.md
@@ -1,3 +1,6 @@
+---
+description: View, filter, and download billing records in the ConnexCS Customer Portal Invoice module, with full visibility into account charges.
+---
 # Invoice
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-ivr.md
+++ b/docs/customer-portal/cp-ivr.md
@@ -1,3 +1,7 @@
+---
+title: Portal IVR | Call Routing Menus
+description: Configure Interactive Voice Response (IVR) phone trees in the ConnexCS Customer Portal, routing callers by number-pad selection to departments.
+---
 # Interactive Voice Response
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-latest-calls.md
+++ b/docs/customer-portal/cp-latest-calls.md
@@ -1,3 +1,7 @@
+---
+title: Portal Latest Calls | Incoming & Outgoing Records
+description: View recent incoming and outgoing call records in the ConnexCS Customer Portal, with customizable columns via the View Columns option.
+---
 # Latest Calls
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-package.md
+++ b/docs/customer-portal/cp-package.md
@@ -1,3 +1,6 @@
+---
+description: View Packages in the ConnexCS Customer Portal, including recurring charge frequency, one-time fees, product description, and auto-deduction rules.
+---
 # Package
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-payment.md
+++ b/docs/customer-portal/cp-payment.md
@@ -1,3 +1,7 @@
+---
+title: Portal Payments | History & CSV Export
+description: View payment history in the ConnexCS Customer Portal. Check the date, amount, and status of every payment, and export records to CSV.
+---
 # Payments
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-queue.md
+++ b/docs/customer-portal/cp-queue.md
@@ -1,3 +1,6 @@
+---
+description: Create a Call Queue in the ConnexCS Customer Portal to route callers to the longest-waiting available member, with hold audio and music.
+---
 # Queue
 
 The **Queue**, same as Groups, allows you to create a team of people in a call queue. The caller is then routed to the next available member (who waits for the longest to receive a call).

--- a/docs/customer-portal/cp-recording.md
+++ b/docs/customer-portal/cp-recording.md
@@ -1,3 +1,6 @@
+---
+description: Listen to recorded calls in the ConnexCS Customer Portal, where available on your account, by selecting a date path to inspect recordings.
+---
 # Recording
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-routes.md
+++ b/docs/customer-portal/cp-routes.md
@@ -1,3 +1,6 @@
+---
+description: View Termination Routes for outbound calls in the ConnexCS Customer Portal, including the associated Rate Card, name, and prefix settings.
+---
 # Routes
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/cp-user-reg.md
+++ b/docs/customer-portal/cp-user-reg.md
@@ -1,3 +1,6 @@
+---
+description: View active SIP User Registrations in the ConnexCS Customer Portal, including username, IP, protocol, NAT status, and TTL details.
+---
 # User registration
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/failover.md
+++ b/docs/customer-portal/failover.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS Failover (Serial Forking) automatically switches to a backup Provider Rate Card if the primary provider fails, keeping service continuous.
+---
 # Failover (Serial Forking)
 
 The failover mechanism guarantees continuous, reliable service by automatically switching to a backup provider rate card(s) in the event of a primary provider failure.

--- a/docs/customer-portal/interconnect.md
+++ b/docs/customer-portal/interconnect.md
@@ -1,3 +1,6 @@
+---
+description: Read-only view of authorized IP addresses and RTP servers used for call routing and media handling in the ConnexCS Customer Portal Interconnect section.
+---
 # Interconnect
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-portal/pbx.md
+++ b/docs/customer-portal/pbx.md
@@ -1,3 +1,6 @@
+---
+description: Overview of PBX features in the ConnexCS Customer Portal for managing calls and interactions, including Conference bridge functionality.
+---
 # Private Branch Exchange (PBX)
 
 In **PBX**, you will find several useful features to help manage calls and interactions.

--- a/docs/customer-portal/status.md
+++ b/docs/customer-portal/status.md
@@ -1,3 +1,7 @@
+---
+title: Customer Status Pages | Outage Reporting
+description: Create Status Pages in the ConnexCS Customer Portal to keep customers informed in real time about service disruptions, outages, and maintenance.
+---
 # Status
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer-ratecard.md
+++ b/docs/customer-ratecard.md
@@ -1,3 +1,6 @@
+---
+description: Build and manage Customer Rate Cards in ConnexCS, generated from provider rate cards to streamline pricing and minimize manual rating errors.
+---
 # Customer Rate Card
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/alerts.md
+++ b/docs/customer/alerts.md
@@ -1,3 +1,7 @@
+---
+title: Customer Alerts | Threshold Notifications
+description: Create Customer Alerts in ConnexCS to notify contacts when key performance metrics cross predefined thresholds, automating proactive monitoring.
+---
 # Alerts
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/alias.md
+++ b/docs/customer/alias.md
@@ -1,3 +1,7 @@
+---
+title: Customer Alias | Per-Account Number Rewriting
+description: Configure Customer Alias in ConnexCS to rewrite numbers, fully or partially, before further call processing for an individual customer account.
+---
 # Alias
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/auth.md
+++ b/docs/customer/auth.md
@@ -1,3 +1,7 @@
+---
+title: Customer Authentication | IP & SIP Setup
+description: Configure Customer Authentication in ConnexCS using IP addresses or SIP username/password credentials, with Global auth options across accounts.
+---
 # Auth
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/cdr.md
+++ b/docs/customer/cdr.md
@@ -1,3 +1,7 @@
+---
+title: Customer CDR | Call Detail Records & Billing
+description: View Customer Call Detail Records (CDR) in ConnexCS, capturing call duration, destination, and other data essential for billing and analytics.
+---
 # Call Detail Record
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/class5.md
+++ b/docs/customer/class5.md
@@ -1,3 +1,6 @@
+---
+description: Configure Class5 telephony and call-handling functionality for a customer account in ConnexCS to enhance their communication experience.
+---
 # Class5
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/cli.md
+++ b/docs/customer/cli.md
@@ -1,5 +1,6 @@
 ---
-title: "Caller Line Identification (CLI) | Routing Rules & Caller ID | ConnexCS"
+title: Customer CLI | Caller ID Fraud Protection
+description: Configure Caller Line Identification (CLI) at the customer level in ConnexCS to sort incoming calls, support billing, and defend against unidentified calls.
 search:
   boost: 3
 ---

--- a/docs/customer/contracts.md
+++ b/docs/customer/contracts.md
@@ -1,3 +1,7 @@
+---
+title: Customer Contracts | Compliance Agreements
+description: Manage Customer Contracts in ConnexCS, listing agreements tied to an account to support compliance, security, and identity verification.
+---
 # Contract
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/custom-reports.md
+++ b/docs/customer/custom-reports.md
@@ -1,3 +1,7 @@
+---
+title: Customer Custom Reports | DTMF & Routing Insights
+description: Build Custom Reports for a ConnexCS customer account, going beyond standard CDRs to analyze DTMF input, rate centers, and technical routing prefixes.
+---
 # Custom Reports
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/customer-page-interface.md
+++ b/docs/customer/customer-page-interface.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Customer Page Interface is a customizable grid for managing customer data, with bulk filtering, editing, and notification actions.
+---
 # Customer Page Interface
 
 ## Overview

--- a/docs/customer/customer.md
+++ b/docs/customer/customer.md
@@ -1,3 +1,6 @@
+---
+description: Understand the intelligent platform features behind ConnexCS Customer account management before you begin setting up your own customers.
+---
 # Customer
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/dialogs.md
+++ b/docs/customer/dialogs.md
@@ -1,3 +1,7 @@
+---
+title: Customer Dialogs | Live Call Tracking
+description: Track a customer's currently active calls in ConnexCS Dialogs, including the Ended status used while a call finishes tearing down and billing.
+---
 # Dialogs
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/did.md
+++ b/docs/customer/did.md
@@ -1,3 +1,7 @@
+---
+title: Customer DID | Direct Inward Dial Numbers
+description: Assign Direct Inward Dial (DID) numbers to a ConnexCS customer so inbound public telephone network calls route directly to their account.
+---
 # Direct Inward Dial (DID)
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/documents.md
+++ b/docs/customer/documents.md
@@ -1,3 +1,7 @@
+---
+title: Customer Documents | KYC File Collection
+description: Collect KYC (Know Your Customer) files and other required documents from a customer account in ConnexCS, with custom notes per request.
+---
 # Documents
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/invoices.md
+++ b/docs/customer/invoices.md
@@ -1,3 +1,6 @@
+---
+description: Manage the ConnexCS invoicing system for seamless customer billing and payment tracking, closing communication gaps between provider and customer.
+---
 # Invoice
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/latest-calls.md
+++ b/docs/customer/latest-calls.md
@@ -1,3 +1,7 @@
+---
+title: Customer Latest Calls | Recent Call Records
+description: View a customer's recent incoming and outgoing calls in ConnexCS, with full SIP traces and simulated test calls for debugging and troubleshooting.
+---
 # Latest Calls
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/main.md
+++ b/docs/customer/main.md
@@ -1,3 +1,7 @@
+---
+title: Customer Main | Core Account Management
+description: Manage core ConnexCS customer functions from the Main tab, including contacts, invoice generation, summary reporting, and number allocation.
+---
 # Main
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/package.md
+++ b/docs/customer/package.md
@@ -1,3 +1,7 @@
+---
+title: Customer Packages | Predefined Service Products
+description: Offer predefined Packages to ConnexCS customers with recurring charges, spend limits, and automatic credit deductions built into each product.
+---
 # Packages
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/payment.md
+++ b/docs/customer/payment.md
@@ -1,3 +1,7 @@
+---
+title: Customer Payments | Add, Track & Manage Transactions
+description: Add, track and manage customer payments in ConnexCS. View full payment history, or handle payments globally across the whole account.
+---
 # Payments
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/route-stats.md
+++ b/docs/customer/route-stats.md
@@ -1,3 +1,6 @@
+---
+description: Review ConnexCS Route Stats by time range, date range, and carrier selectors to analyze routing performance for a customer account.
+---
 # Route Stats
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/routing.md
+++ b/docs/customer/routing.md
@@ -1,3 +1,6 @@
+---
+description: 'How ConnexCS Ingress Routing works for a customer: traffic entry, authentication checks, and routing to a Customer Rate Card and onward provider.'
+---
 # Ingress Routing
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/stats.md
+++ b/docs/customer/stats.md
@@ -1,3 +1,7 @@
+---
+title: Customer Stats | Call Quality & Traffic Analytics
+description: View Customer Stats graphs in ConnexCS for call quality, traffic performance, carrier efficiency, and overall account activity analytics.
+---
 # Stats
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/tags.md
+++ b/docs/customer/tags.md
@@ -1,3 +1,6 @@
+---
+description: Create Tags in ConnexCS to categorize customers and apply global Alerts and Routing Strategies automatically wherever the tag is assigned.
+---
 # Tags
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/customer/transcriptions.md
+++ b/docs/customer/transcriptions.md
@@ -1,3 +1,7 @@
+---
+title: Customer Transcriptions | Call-to-Text Records
+description: Access customer-level call transcription records in ConnexCS, linking to the full Transcription feature for converting calls into text.
+---
 # Transcription
 
 [Click here](https://docs.connexcs.com/transcription/) to know about the Transcription feature.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,3 +1,7 @@
+---
+title: Control Panel Dashboard | Live System Overview
+description: The ConnexCS Control Panel Dashboard gives a real-time overview of live channels, active customers, carriers, and rate cards in one monitoring view.
+---
 # Dashboard
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS Reference Data Sets validate numbers, flag compliance risks, assess IP reputation, and support real-time routing and fraud-prevention decisions.
+---
 # ConnexCS Reference Data Sets
 
 ---

--- a/docs/datasuite.md
+++ b/docs/datasuite.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS Data Suite helps you collect, process, and analyze data across its lifecycle, with tools for organizing and optimizing platform data.
+---
 # Data Suite
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/developers/analytics.md
+++ b/docs/developers/analytics.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Analytics section gathers, manipulates, and displays graphical and tabular data, letting you edit existing reports or build your own.
+---
 # Analytics
 
 **Developer :material-menu-right: Analytics**

--- a/docs/developers/button-builder.md
+++ b/docs/developers/button-builder.md
@@ -1,3 +1,7 @@
+---
+title: Button Builder | Developer Pages Reference
+description: Use Button Builder with ConnexCS Pages to add a custom button to an existing site menu, such as selecting multiple customers or DIDs at once.
+---
 # Button Builder
 
 **Developer :material-menu-right: Button Builder**

--- a/docs/developers/database.md
+++ b/docs/developers/database.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS developer Database reference for custom persistent data storage, scoped per customer or global, for lookups, caching, or stateful apps.
+---
 # Database
 
 **Developer :material-menu-right: Database**

--- a/docs/developers/pages/advance-field.md
+++ b/docs/developers/pages/advance-field.md
@@ -1,3 +1,6 @@
+---
+description: Organize ConnexCS Page Builder data with Advanced Grid fields and DataTables, adding visual effects through Graph and Dialog options.
+---
 # Advance Field
 
 You can further enhance your form with Advance Fields

--- a/docs/developers/pages/basic-field.md
+++ b/docs/developers/pages/basic-field.md
@@ -1,3 +1,6 @@
+---
+description: Reference for Basic Fields in the ConnexCS Page Builder, the standard form elements used to build simple widgets, with validation examples.
+---
 # Basic Field 
 
 Basic Fields include a collection of standard elements that can be used to create simple widgets for creating forms. A detailed description of all the Basic Fields are discussed below.

--- a/docs/developers/pages/introduction.md
+++ b/docs/developers/pages/introduction.md
@@ -1,3 +1,6 @@
+---
+description: 'Introduction to ConnexCS Pages: use the Page Builder to customize the Control Panel, Customer Portal, and Web Phone across Carrier and Customer areas.'
+---
 # Pages
 
 Using Page Builder, you can customise the Control Panel, Customer Portal, and Web Phone. Pages help you enhance the functionality of these interfaces.

--- a/docs/developers/pages/layout.md
+++ b/docs/developers/pages/layout.md
@@ -1,3 +1,6 @@
+---
+description: Reference for Layout Fields in the ConnexCS Page Builder, controlling element alignment such as Start, End, Center, and Space Around positioning.
+---
 # Layout Fields 
 
 Layout fields can be used to organize the various elements and enhance the form's overall design. 

--- a/docs/developers/scriptforge.md
+++ b/docs/developers/scriptforge.md
@@ -1,3 +1,6 @@
+---
+description: Write ES6 JavaScript in ConnexCS ScriptForge and run it in a secure, low-latency sandbox built for scripts and small applications, not large workloads.
+---
 # ScriptForge
 
 **Developer :material-menu-right: ScriptForge**

--- a/docs/dnc.md
+++ b/docs/dnc.md
@@ -1,3 +1,6 @@
+---
+description: Configure Do Not Call (DNC) list handling in ConnexCS to help carriers stay compliant and avoid the fines and prosecution risk of ignoring DNC entries.
+---
 # Do Not Call Lists
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/far-end-nat-traversal.md
+++ b/docs/far-end-nat-traversal.md
@@ -1,3 +1,6 @@
+---
+description: Understand Far-End NAT Traversal in ConnexCS, why SIP ALG support varies across firewalls and gateways, and how it affects call setup through NAT.
+---
 # Far-End Network Address Translation Traversal
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -1,3 +1,6 @@
+---
+description: Browse the comprehensive list of features included in the latest stable version of the ConnexCS platform, from routing to billing to reporting.
+---
 # Detailed Features
 
 Please [click here](https://connexcs.com/feature-list) to have look at our comprehensive feature list.

--- a/docs/files.md
+++ b/docs/files.md
@@ -1,3 +1,6 @@
+---
+description: Manage the ConnexCS File module, a centralized library for media and documents used by recordings, voicemail, provider cards, and public assets.
+---
 # File
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,6 @@
+---
+description: 'Get started with ConnexCS: a walkthrough of the key features and settings you need to begin managing customers, carriers, and rate cards on the platform.'
+---
 # Getting Started
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/global-alias.md
+++ b/docs/global-alias.md
@@ -1,3 +1,7 @@
+---
+title: Global Alias | Account-Wide Number Rewriting
+description: Configure Global Alias in ConnexCS to rewrite numbers, fully or partially, before further call processing across your whole account, by company or country.
+---
 # Alias
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/global-routing.md
+++ b/docs/global-routing.md
@@ -1,3 +1,6 @@
+---
+description: Create Global Routing templates in ConnexCS to apply a repeatable routing configuration across multiple customers who share the same route settings.
+---
 # Routing Global
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/global.md
+++ b/docs/global.md
@@ -1,3 +1,6 @@
+---
+description: Use the ConnexCS Global section for an account-wide overview of Customer and Carrier management data, improving oversight across every account.
+---
 # Global
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/globalaiagent.md
+++ b/docs/globalaiagent.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Global AI Agent is an integrated assistant that handles informational queries and action-based operations to streamline platform workflows.
+---
 # Global AI Agent
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/3dig-ext.md
+++ b/docs/guides/3dig-ext.md
@@ -1,3 +1,6 @@
+---
+description: Set up 3-Digit Extension Dialling in ConnexCS with a quick internal number block configuration for fast, basic deployment.
+---
 # 3-Digit Extension Dialling
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/billing-guide.md
+++ b/docs/guides/billing-guide.md
@@ -1,3 +1,6 @@
+---
+description: 'ConnexCS Billing Guide: use CDRs as the source of truth for billing and invoice discrepancies, and avoid basing charges on account balance changes.'
+---
 # Billing Guide
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/call-disconnection-reasons.md
+++ b/docs/guides/call-disconnection-reasons.md
@@ -1,3 +1,6 @@
+---
+description: Diagnose ConnexCS call disconnection reasons, including downstream and upstream BYE messages, to troubleshoot premature call termination.
+---
 # Call Disconnection Reasons and Premature Call Disconnection
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/capacity-planning.md
+++ b/docs/guides/capacity-planning.md
@@ -1,3 +1,6 @@
+---
+description: Plan ConnexCS platform capacity by assessing current traffic percentages, infrastructure load, and Media Proxy volume requirements.
+---
 # Capacity Planning
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/cdr-heuristics.md
+++ b/docs/guides/cdr-heuristics.md
@@ -1,3 +1,6 @@
+---
+description: CDR Heuristics is a ConnexCS carrier intelligence tool that analyzes Call Detail Records to reveal hidden carrier behavior, routing issues, and quality trends.
+---
 # CDR Heuristics
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/cdr-retention.md
+++ b/docs/guides/cdr-retention.md
@@ -1,3 +1,6 @@
+---
+description: Understand Call Detail Record (CDR) retention in ConnexCS, including what data each record contains and how long it's kept for compliance.
+---
 # Call Detail Record Retention
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/channel-limitations.md
+++ b/docs/guides/channel-limitations.md
@@ -1,3 +1,6 @@
+---
+description: Apply Channel Limitation settings across the ConnexCS platform, with several configuration locations to cap concurrent call channels.
+---
 # Channel Limitation Settings
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -1,3 +1,6 @@
+---
+description: 'Debugging basics for the ConnexCS Voice Platform: isolate call problems methodically before diagnosing VoIP and SIP configuration issues.'
+---
 # Debugging Basics
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/doc-guide.md
+++ b/docs/guides/doc-guide.md
@@ -1,3 +1,6 @@
+---
+description: Guide to the customer document types available in ConnexCS, and how to view and manage them from within individual customer accounts.
+---
 # Guide to Customer Documents
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/gdpr.md
+++ b/docs/guides/gdpr.md
@@ -1,3 +1,6 @@
+---
+description: Understand GDPR compliance for VoIP operators and carriers serving the EU market, covering how personal user data must be collected and processed.
+---
 # Understanding General Data Protection Regulation
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/howto/callid.md
+++ b/docs/guides/howto/callid.md
@@ -1,3 +1,6 @@
+---
+description: 'Learn what a Call-ID is in ConnexCS: a unique identifier generated at call origination and present in every SIP packet sent or received.'
+---
 
 # What's a Call-ID?
 

--- a/docs/guides/howto/restrict-calling-plan.md
+++ b/docs/guides/howto/restrict-calling-plan.md
@@ -1,3 +1,6 @@
+---
+description: Restrict ConnexCS customers to specific calling plans using a temporary prefix in User Auth, tagging calls for appropriate destination routing.
+---
 # Restricting individual customers to specific calling plans
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/kyc.md
+++ b/docs/guides/kyc.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS KYC and Customer Due Diligence procedures verify customer identity, prevent fraud, and support compliance with UK GDPR and the Data Protection Act.
+---
 # KYC & Identity Verification
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/kyc.md
+++ b/docs/guides/kyc.md
@@ -220,7 +220,7 @@ To raise a complaint about how ConnexCS handles your personal data, contact the 
 
 For full details of data processing activities, refer to the [ConnexCS Privacy Notice](https://connexcs.com/company-policies/data-privacy-policy).
 
-For any other assistance contact our Support team at [support@connexcs.com](support@connexcs.com).
+For any other assistance contact our Support team at [support@connexcs.com](mailto:support@connexcs.com).
 
 ---
 

--- a/docs/guides/major-telecom-regulatory-authorities.md
+++ b/docs/guides/major-telecom-regulatory-authorities.md
@@ -1,3 +1,6 @@
+---
+description: Reference guide to major telecom regulatory authorities worldwide, helping VoIP providers understand the country-specific rules they must follow.
+---
 # Governing Bodies
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS Monitoring tools for Customers and Carriers help you plan, bill, and troubleshoot, with All Customer Monitoring under Management.
+---
 # Monitoring Guide
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/osi-model.md
+++ b/docs/guides/osi-model.md
@@ -1,3 +1,6 @@
+---
+description: Understand the OSI Model's seven networking layers, the 1980s industry standard that computer and telecom companies still build on today.
+---
 # Open Systems Interconnections Model
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/remote-testing.md
+++ b/docs/guides/remote-testing.md
@@ -1,3 +1,6 @@
+---
+description: Run Remote Testing in the ConnexCS Control Panel under Global > Weylon to provision and review tests; result visualization reports are in development.
+---
 # Remote Testing
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/sip-traces.md
+++ b/docs/guides/sip-traces.md
@@ -1,3 +1,6 @@
+---
+description: Use SIP Traces, Pings, and Messages in ConnexCS to diagnose call setup, maintenance, and tear-down issues; call quality needs other troubleshooting tools.
+---
 # SIP Traces, Pings and Messages
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/spam-callsblock.md
+++ b/docs/guides/spam-callsblock.md
@@ -1,3 +1,6 @@
+---
+description: Enable Spam Protection features in ConnexCS to block fraudulent and unwanted calls that attempt to trick victims into revealing personal data.
+---
 # Enabling Spam Protection Features
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/stir-shaken-fcc.md
+++ b/docs/guides/stir-shaken-fcc.md
@@ -1,3 +1,6 @@
+---
+description: Understand FCC STIR/SHAKEN regulations on illegal robocalling and caller ID spoofing, and how ConnexCS providers should provision mitigation.
+---
 # Federal Communication Commission Regulations on Secure Telephony Identity Revisited / SHAKEN
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/tshoot-media.md
+++ b/docs/guides/tshoot-media.md
@@ -1,3 +1,6 @@
+---
+description: Troubleshoot Media (audio payload) issues in ConnexCS, covering RTP servers and why UDP transmission trades some loss for higher throughput.
+---
 # Troubleshoot Media
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/guides/tshoot-signal.md
+++ b/docs/guides/tshoot-signal.md
@@ -1,3 +1,6 @@
+---
+description: Troubleshoot SIP Signaling issues in ConnexCS, covering device registration, call setup, maintenance, and tear-down over the SIP protocol.
+---
 # Troubleshoot Signaling
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/hearth.md
+++ b/docs/hearth.md
@@ -1,3 +1,6 @@
+---
+description: Hearth is a secure, multi-tenant database for ConnexCS developers to create schemas, store structured data, and query it via REST API or the JS/TS SDK.
+---
 # Hearth
 
 <details>

--- a/docs/ide.md
+++ b/docs/ide.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS IDE is a centralized workspace for building, customizing, and managing applications, workflows, and integrations without switching tools.
+---
 # IDE
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+title: ConnexCS Documentation | Cloud Softswitch Platform
+description: Official ConnexCS documentation covering setup, configuration, monitoring, and troubleshooting for the cloud-based VoIP switching and billing platform.
+---
 ConnexCS User Documentation
 ========================
 

--- a/docs/limiting-cps.md
+++ b/docs/limiting-cps.md
@@ -1,3 +1,6 @@
+---
+description: Limit Calls Per Second (CPS) and channel counts in ConnexCS at the account, carrier, or customer level to cap traffic flow and protect capacity.
+---
 # Capacity Limiting
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/logging-out.md
+++ b/docs/logging-out.md
@@ -1,3 +1,6 @@
+---
+description: Learn how to log out of the ConnexCS Control Panel safely using the account menu in the top-right corner of the page, ending your active session.
+---
 # Logging out of the ConnexCS Control Panel
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,3 +1,6 @@
+---
+description: Use ConnexCS Logging to check real-time call attempts, SIP traces, and routing status, and simulate calls for most day-to-day issue debugging.
+---
 # Logging
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/makecall.md
+++ b/docs/makecall.md
@@ -1,3 +1,6 @@
+---
+description: 'Reference for the ConnexCS makeCall API: how the call is initiated, the Promise it returns, and how the Event Manager handles the resulting call.'
+---
 # Some Interesting Features
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/mcpserver.md
+++ b/docs/mcpserver.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS MCP Server lets AI assistants securely access ConnexCS tools and platform data using the Model Context Protocol for natural-language control.
+---
 # ConnexCS MCP Server
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/number-manipulation.md
+++ b/docs/number-manipulation.md
@@ -1,3 +1,6 @@
+---
+description: Perform number manipulation in ConnexCS under Customer management, including parameter rewrite, alias modification, and CLI rewrite routing rules.
+---
 # Number Manipulation
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/provider-ratecard.md
+++ b/docs/provider-ratecard.md
@@ -1,3 +1,6 @@
+---
+description: Set up Provider Rate Cards in ConnexCS to define carrier pricing, per-minute rates, billing increments, rounding rules, and routing parameters.
+---
 # Provider Rate Cards
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/rate-card-building.md
+++ b/docs/rate-card-building.md
@@ -1,3 +1,6 @@
+---
+description: Overview of Rate Cards in ConnexCS and how they organize pricing and routing information so calls are priced correctly and routed efficiently.
+---
 # Rate Card Overview
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/report.md
+++ b/docs/report.md
@@ -1,3 +1,6 @@
+---
+description: Generate and download ConnexCS Reports for historical insights by customer or provider route, DTMF cost, and per-number metrics, with scheduling.
+---
 # Report
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/reporting-problems.md
+++ b/docs/reporting-problems.md
@@ -1,3 +1,6 @@
+---
+description: 'How ConnexCS Customer Support works: response expectations, severity-based resolution timeframes, and options for dedicated NOC support on demand.'
+---
 # Customer Support
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/routing-strategy.md
+++ b/docs/routing-strategy.md
@@ -1,3 +1,6 @@
+---
+description: Configure a Routing Strategy in ConnexCS to route calls through the routing engine using a specified rule set matched to your business needs.
+---
 # Routing Strategy
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/routing-usa.md
+++ b/docs/routing-usa.md
@@ -1,3 +1,6 @@
+---
+description: Configure USA Routing in ConnexCS using NPA-NXX and LRN number formats, with inter/intra-state routing based on the CLI or ANI presented in the call.
+---
 # USA Routing
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,3 +1,6 @@
+---
+description: 'How ConnexCS Routing works: customer identification, Ingress Routing against rate cards, and how Rate Cards represent call paths to carriers.'
+---
 # Routing
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/scaling-load-balancing.md
+++ b/docs/scaling-load-balancing.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS scales channels, CPS, and traffic across single or multiple zones, with every server and zone configurable from one control panel.
+---
 # Scaling and Load Balancing
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,6 @@
+---
+description: Overview of ConnexCS security practices and policies, covering the technology and procedures used to protect the platform from internal and external threats.
+---
 # Security
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/account-manager/commission.md
+++ b/docs/setup/account-manager/commission.md
@@ -1,3 +1,6 @@
+---
+description: Set up Commission payouts to your ConnexCS Account Manager. This feature is currently in Alpha and under active development.
+---
 # Commission
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/account-manager/payment.md
+++ b/docs/setup/account-manager/payment.md
@@ -1,3 +1,7 @@
+---
+title: Account Manager Payments | Record Payouts
+description: Record payments made to your ConnexCS Account Manager and track payout history. This feature is currently in Alpha version.
+---
 # Payment
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/advanced/firewall.md
+++ b/docs/setup/advanced/firewall.md
@@ -1,3 +1,6 @@
+---
+description: Block attacker IP addresses with the ConnexCS Firewall's threat detection system, adding single-IP block rules with optional notes.
+---
 # Firewall
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/advanced/fraud.md
+++ b/docs/setup/advanced/fraud.md
@@ -1,3 +1,6 @@
+---
+description: Configure the ConnexCS Fraud Profile for flexible, rule-based fraud detection and mitigation if an account is ever compromised.
+---
 # Fraud Profile
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/advanced/language.md
+++ b/docs/setup/advanced/language.md
@@ -1,3 +1,6 @@
+---
+description: Customize the ConnexCS interface Language, adding non-English word equivalents or revising the platform's default terminology.
+---
 # Language
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/advanced/prefix-set.md
+++ b/docs/setup/advanced/prefix-set.md
@@ -1,3 +1,6 @@
+---
+description: Group multiple prefixes into a ConnexCS Prefix Set and apply it to a Customer or Route, avoiding manual per-item configuration and errors.
+---
 # Prefix Sets
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/advanced/reseller.md
+++ b/docs/setup/advanced/reseller.md
@@ -1,3 +1,6 @@
+---
+description: Enable Reseller Account functionality in ConnexCS to resell carrier services through a reseller or agent. Currently an Alpha feature.
+---
 # Reseller Account
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/advanced/rtp-block.md
+++ b/docs/setup/advanced/rtp-block.md
@@ -1,3 +1,6 @@
+---
+description: Use RTP Block (Block Media IP) in ConnexCS to stop a specific IP address from sending media on your platform, configured under Advanced settings.
+---
 # RTP Block
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/appstore.md
+++ b/docs/setup/appstore.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS Anvil App Store is the central marketplace for discovering, installing, publishing, and managing applications on the platform.
+---
 # App Store
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/config/contracts.md
+++ b/docs/setup/config/contracts.md
@@ -1,3 +1,7 @@
+---
+title: Configuring Contracts | Compliance Setup
+description: Configure Contracts in ConnexCS to require customer approval before dialing, with a grace period before unapproved contracts block calls.
+---
 # Contracts
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/config/packages.md
+++ b/docs/setup/config/packages.md
@@ -1,3 +1,7 @@
+---
+title: Configuring Packages | Global Service Products
+description: Configure global Packages in ConnexCS representing recurring or one-time products, allocated to each customer according to their needs.
+---
 # Packages
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/config/sip-profile.md
+++ b/docs/setup/config/sip-profile.md
@@ -1,3 +1,6 @@
+---
+description: Group SIP users with a common feature set using SIP Profiles in ConnexCS, useful for call centers with agents and operators needing different access.
+---
 # SIP Profile
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/config/templates.md
+++ b/docs/setup/config/templates.md
@@ -1,3 +1,6 @@
+---
+description: Create Templates in ConnexCS using the Handlebars language to customize outbound email, SMS, Customer Portal, and WebPhone content.
+---
 # Templates
 
 **Setup :material-menu-right: Config :material-menu-right: Templates**

--- a/docs/setup/information/audit-log.md
+++ b/docs/setup/information/audit-log.md
@@ -1,3 +1,6 @@
+---
+description: Review the ConnexCS Audit Log for a chronological record of every configuration change, with timestamps, IPs, and before/after differences.
+---
 # Audit Log
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/information/certificate.md
+++ b/docs/setup/information/certificate.md
@@ -1,3 +1,6 @@
+---
+description: Manage SSL Certificates in ConnexCS using free Let's Encrypt certificates or your own user-provided certificate for secure connections.
+---
 # Certificate
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/information/change-log.md
+++ b/docs/setup/information/change-log.md
@@ -1,3 +1,6 @@
+---
+description: Browse the ConnexCS Change Log, a chronological record of notable platform updates for tracking how the product evolves over time.
+---
 # Introduction
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/information/dial-code-destination.md
+++ b/docs/setup/information/dial-code-destination.md
@@ -1,3 +1,6 @@
+---
+description: Look up international numbering plans in the ConnexCS Dial Code / Destination database by country and prefix to check number type and provider.
+---
 # Dial Code / Destination
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/information/feature-request.md
+++ b/docs/setup/information/feature-request.md
@@ -1,3 +1,6 @@
+---
+description: Submit and track Feature Requests in ConnexCS, suggestions for new functionality or enhancements from customers, partners, and internal teams.
+---
 # Feature Request
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/information/jobs.md
+++ b/docs/setup/information/jobs.md
@@ -1,3 +1,6 @@
+---
+description: Monitor ConnexCS Jobs by status (Completed, Failed, Active, Delayed, Wait), covering email sends, server checks, and SIP tests.
+---
 # Jobs
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/information/payment-log.md
+++ b/docs/setup/information/payment-log.md
@@ -1,3 +1,6 @@
+---
+description: Review the ConnexCS Payment Log for debugging payments made through the Customer Portal or via PayPal Instant Payment Notification (IPN).
+---
 # Payment Log
 
 ---

--- a/docs/setup/information/statements.md
+++ b/docs/setup/information/statements.md
@@ -1,3 +1,6 @@
+---
+description: Analyze ConnexCS Statements using the Columns section to drill down into Return on Sales (ROS) and other detailed financial values.
+---
 # Statement
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/information/stir-shaken.md
+++ b/docs/setup/information/stir-shaken.md
@@ -1,3 +1,6 @@
+---
+description: Add a STIR/SHAKEN Certificate in ConnexCS to authenticate outbound calls, improve caller ID trust, and mitigate spoofing and robocalling.
+---
 # STIR / SHAKEN Cert
 
 **Setup :material-menu-right: Information :material-menu-right: STIR/SHAKEN Cert**

--- a/docs/setup/integrations/api.md
+++ b/docs/setup/integrations/api.md
@@ -1,3 +1,7 @@
+---
+title: API Integrations | Connect External Services
+description: Configure API Integrations in ConnexCS to connect external systems and payment processors, with inbound API details in Architecture docs.
+---
 # Application Programming Interface Integrations
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/integrations/jwt.md
+++ b/docs/setup/integrations/jwt.md
@@ -1,3 +1,6 @@
+---
+description: Manage JWT Keys in ConnexCS, including the Refresh Token that keeps user sessions seamless while improving authentication security.
+---
 # JWT Keys
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/integrations/oauth.md
+++ b/docs/setup/integrations/oauth.md
@@ -1,3 +1,6 @@
+---
+description: Use OAuth Session integrations in ConnexCS for secure sign-in, token issuance, and automatic session refresh with external systems.
+---
 # OAuth Session
 
 **Setup :material-menu-right: Integrations :material-menu-right: OAUth Session**

--- a/docs/setup/integrations/portal.md
+++ b/docs/setup/integrations/portal.md
@@ -1,3 +1,7 @@
+---
+title: Customer Portal Domains | Multi-Brand Setup
+description: Add domains and sub-domains to the ConnexCS Control Panel for Customer Portal access, with per-domain branding, permissions, and currency.
+---
 # Portal
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/network-ping.md
+++ b/docs/setup/network-ping.md
@@ -1,3 +1,6 @@
+---
+description: Test IP address reachability from ConnexCS servers worldwide with the Network Ping tool, currently in Alpha and under active development.
+---
 # Network Ping
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/settings/account.md
+++ b/docs/setup/settings/account.md
@@ -1,3 +1,6 @@
+---
+description: 'Manage your ConnexCS Account settings: Company and General Information, SMTP details, Packages, and the Service Agreement in one overview.'
+---
 # Account
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/settings/dns.md
+++ b/docs/setup/settings/dns.md
@@ -1,3 +1,6 @@
+---
+description: Use ConnexCS managed DNS built for VoIP delivery, including a white-labeled .sip.direct domain you can use directly or set up as a CNAME.
+---
 # Domain Name System
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/settings/options.md
+++ b/docs/setup/settings/options.md
@@ -1,3 +1,6 @@
+---
+description: Configure system-wide default Options in ConnexCS, including the Internal SIP Code Rewrite setting for revising existing SIP codes.
+---
 # Options
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/settings/payments.md
+++ b/docs/setup/settings/payments.md
@@ -1,3 +1,6 @@
+---
+description: Overview of transactions, invoices, and payment methods in ConnexCS Settings, used to manage payments made to ConnexCS itself.
+---
 # Payments
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/settings/rtp-zones.md
+++ b/docs/setup/settings/rtp-zones.md
@@ -1,3 +1,6 @@
+---
+description: Configure RTP Zones in ConnexCS to change the media proxy zone by location, recommended as a fallback if Closest (Elastic) Server has issues.
+---
 # RTP Zones
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/settings/servers.md
+++ b/docs/setup/settings/servers.md
@@ -1,3 +1,6 @@
+---
+description: Manage ConnexCS server infrastructure under Settings, including monitoring, configuration, authentication, and load balancing per server.
+---
 # Servers
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/setup/settings/users.md
+++ b/docs/setup/settings/users.md
@@ -1,3 +1,6 @@
+---
+description: Create Users and Groups in ConnexCS Settings to manage granular, permission-based access to the Control Panel at every endpoint.
+---
 # User
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/sip-devices.md
+++ b/docs/sip-devices.md
@@ -1,3 +1,6 @@
+---
+description: Provision SIP devices in ConnexCS by MAC, IMEI, or UUID for direct customer device setup. This feature is currently in Alpha version.
+---
 # Session Initiation Protocol Devices
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,3 +1,6 @@
+---
+description: Technical specification for the ConnexCS Class 4 Softswitch, a massively scalable distributed switching system deployable globally with minimal setup.
+---
 # Class 4 Softswitch
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/system-status.md
+++ b/docs/system-status.md
@@ -1,3 +1,7 @@
+---
+title: System Status | Platform Health & Outages
+description: Create Status Pages in ConnexCS to report outages and issues on customer portals, automating downtime communication to your customers.
+---
 # Status
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -1,3 +1,7 @@
+---
+title: Tags | Route, Alert & CLI Templates
+description: Use Tags in ConnexCS to link Routes, Alerts, and CLI rules to customers automatically, generating global configuration wherever a tag is applied.
+---
 # Tags
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/terminal-tools.md
+++ b/docs/terminal-tools.md
@@ -1,3 +1,6 @@
+---
+description: CX-Tools brings script management, SQL queries, key-value store access, deployments, and app management to ConnexCS in a single extensible CLI.
+---
 # Terminal Tools
 
 ---

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -1,3 +1,7 @@
+---
+title: Call Transcription | Voice-to-Text Service
+description: Convert live or recorded ConnexCS calls into text with the Call Transcription service, available in English by default with more languages on request.
+---
 # Transcription
 
 **Global :material-menu-right: Transcription**

--- a/docs/video-guide.md
+++ b/docs/video-guide.md
@@ -1,3 +1,6 @@
+---
+description: ConnexCS video walkthroughs covering rate card setup, routing, global routing, CLI restrictions, aliases, bulk edit, ScriptForge, and Customer Portal setup.
+---
 # Video Guide
 
 ### Rate Card Setup

--- a/docs/voucher.md
+++ b/docs/voucher.md
@@ -1,3 +1,6 @@
+---
+description: Issue and manage ConnexCS Vouchers, setting a fixed value and Minimum Activation spend before the system generates redeemable voucher codes.
+---
 # Vouchers
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/webphone.md
+++ b/docs/webphone.md
@@ -1,3 +1,6 @@
+---
+description: The legacy ConnexCS Web Phone runs in-browser with no install required. Development is on hold; new deployments should use the WebPhone App instead.
+---
 # Webphone
 
 !!! Warning

--- a/docs/webphoneapp.md
+++ b/docs/webphoneapp.md
@@ -1,3 +1,6 @@
+---
+description: The ConnexCS WebPhone App is a fully customizable, browser-based softphone built on the App Platform, replacing the legacy Web Phone Application.
+---
 # WebPhone App
 
 <details> <summary><strong>Document Metadata</strong></summary> <br>

--- a/docs/workflows-guide.md
+++ b/docs/workflows-guide.md
@@ -1,3 +1,6 @@
+---
+description: Common ConnexCS workflows for account verification, carrier setup, and authentication, walking through Getting Started and Carrier configuration steps.
+---
 # Common Workflows Guide
 
 **Purpose:** Step-by-step workflows for common tasks in ConnexCS  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,8 @@ site_description: Connex Cloud Softswitch
 site_author: ConnexCS Team
 theme:
   name: material
-  font: false 
+  custom_dir: overrides
+  font: false
   features:
     - navigation.instant
     - navigation.tabs

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block site_meta %}
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  {% if page.meta and page.meta.description %}
+    <meta name="description" content="{{ page.meta.description }}">
+  {% elif config.site_description %}
+    <meta name="description" content="{{ config.site_description }}">
+  {% endif %}
+  {% if page.meta and page.meta.author %}
+    <meta name="author" content="{{ page.meta.author }}">
+  {% elif config.site_author %}
+    <meta name="author" content="{{ config.site_author }}">
+  {% endif %}
+  {% if page.meta and page.meta.canonical_url %}
+    <link rel="canonical" href="{{ page.meta.canonical_url }}">
+  {% elif page.canonical_url %}
+    <link rel="canonical" href="{{ page.canonical_url }}">
+  {% endif %}
+  {% if page.previous_page %}
+    <link rel="prev" href="{{ page.previous_page.url | url }}">
+  {% endif %}
+  {% if page.next_page %}
+    <link rel="next" href="{{ page.next_page.url | url }}">
+  {% endif %}
+  {% if config.extra.alternate is iterable %}
+    {% for alt in config.extra.alternate %}
+      <link rel="alternate" href="{{ alt.link | url }}" hreflang="{{ alt.lang | d(lang.t('language')) }}">
+    {% endfor %}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Adds a unique meta description to every page the SEO audit flagged as sharing the site-wide default ("Connex Cloud Softswitch"), and a disambiguated title to the 27 groups of pages that fell back to identical short nav labels (Payment, CDR, Alert, etc.) in the browser tab and search results.

Also wires up theme.custom_dir with an overrides/main.html that makes page.meta.canonical_url actually take effect — previously set on one page but silently ignored by the default Material template.